### PR TITLE
Migrate project to Typescript 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ let data = [
     columns: [
       { label: 'User', value: 'user' }, // Top level data
       { label: 'Age', value: row => (row.age + ' years') }, // Run functions
-      { label: 'Phone', value: row => (row.more ? row.more.phone || '' : '') }, // Deep props
+      { label: 'Phone', value: 'user.more.phone' }, // Deep props
     ],
     content: [
       { user: 'Manuel', age: 16, more: { phone: '99999999' } },

--- a/index.ts
+++ b/index.ts
@@ -102,6 +102,7 @@ function xlsx(jsonSheets: IJsonSheet[], settings: ISettings = {}): Buffer | unde
 }
 
 export default xlsx
-export {getContentProperty}
+export {getContentProperty, getJsonSheetRow}
 module.exports = xlsx
 module.exports.getContentProperty = getContentProperty
+module.exports.getJsonSheetRow = getJsonSheetRow

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { utils, write, writeFile } from 'xlsx'
-import { IColumn, IData, ISettings } from './types/index'
+import { IColumn, IJsonSheet, ISettings } from './types/index'
 
-module.exports = (data: IData[], settings: ISettings = {}) => {
+module.exports = (data: IJsonSheet[], settings: ISettings = {}) => {
   const extraLength = settings.extraLength === undefined ? 1 : settings.extraLength
   const writeOptions = settings.writeOptions === undefined ? {} : settings.writeOptions
   const wb = utils.book_new() // Creating a workbook, this is the name given to an Excel file

--- a/index.ts
+++ b/index.ts
@@ -62,18 +62,21 @@ function writeWorkbook(workbook: WorkBook, settings: ISettings = {}): Buffer | u
     : writeFile(workbook, filename, writeOptions)
 }
 
-function xlsx(data: IJsonSheet[], settings: ISettings = {}): Buffer | undefined {
+function xlsx(jsonSheets: IJsonSheet[], settings: ISettings = {}): Buffer | undefined {
 
-  if (!data.length) {
+  if (!jsonSheets.length) {
     return
   }
 
-  const wb = utils.book_new() // Creating a workbook, this is the name given to an Excel file
-  data.forEach((actualSheet, actualIndex) => {
-    const newSheet = getWorksheet(actualSheet, settings)
-    utils.book_append_sheet(wb, newSheet, `${actualSheet.sheet ?? `Sheet ${actualIndex + 1}`}`) // Add Worksheet to Workbook
+  const workbook = utils.book_new() // Creating a workbook, this is the name given to an Excel file
+  jsonSheets.forEach((actualSheet, actualIndex) => {
+    const worksheet = getWorksheet(actualSheet, settings)
+    const worksheetName = actualSheet.sheet ?? `Sheet ${actualIndex + 1}`
+
+    utils.book_append_sheet(workbook, worksheet, worksheetName) // Add Worksheet to Workbook
   })
-  return writeWorkbook(wb, settings)
+
+  return writeWorkbook(workbook, settings)
 }
 
 export default xlsx

--- a/index.ts
+++ b/index.ts
@@ -102,4 +102,6 @@ function xlsx(jsonSheets: IJsonSheet[], settings: ISettings = {}): Buffer | unde
 }
 
 export default xlsx
+export {getContentProperty}
 module.exports = xlsx
+module.exports.getContentProperty = getContentProperty

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
 import { utils, write, writeFile } from 'xlsx'
 import { IColumn, IJsonSheet, ISettings } from './types/index'
 
-module.exports = (data: IJsonSheet[], settings: ISettings = {}) => {
+function xlsx(data: IJsonSheet[], settings: ISettings = {}): Buffer | undefined {
   const extraLength = settings.extraLength === undefined ? 1 : settings.extraLength
   const writeOptions = settings.writeOptions === undefined ? {} : settings.writeOptions
   const wb = utils.book_new() // Creating a workbook, this is the name given to an Excel file
@@ -40,3 +40,6 @@ module.exports = (data: IJsonSheet[], settings: ISettings = {}) => {
   })
   return writeOptions.type === 'buffer' ? write(wb, writeOptions) : writeFile(wb, `${settings.fileName ?? 'Spreadsheet'}.xlsx`, writeOptions)
 }
+
+export default xlsx
+module.exports = xlsx

--- a/index.ts
+++ b/index.ts
@@ -1,6 +1,28 @@
 import {utils, WorkBook, WorkSheet, write, writeFile} from 'xlsx'
 import {IColumn, IContent, IJsonSheet, IJsonSheetRow, ISettings, IWorksheetColumnWidth} from './types'
 
+function getContentProperty(content: IContent, property: string): string | number | boolean | Date | IContent {
+
+  function accessContentProperties(content: IContent, properties: string[]): string | number | boolean | Date | IContent  {
+
+    const value = content[properties[0]]
+
+    if (properties.length === 1) {
+      return value ?? ""
+    }
+
+    if (value === undefined || typeof value === 'string' || typeof value === 'boolean' ||
+      typeof value === 'number'|| value instanceof Date) {
+      return ""
+    }
+
+    return accessContentProperties(value, properties.slice(1))
+  }
+
+  const properties = property.split(".")
+  return accessContentProperties(content, properties)
+}
+
 function getJsonSheetRow(content: IContent, columns: IColumn[]): IJsonSheetRow {
 
   let jsonSheetRow: IJsonSheetRow = {}
@@ -8,7 +30,7 @@ function getJsonSheetRow(content: IContent, columns: IColumn[]): IJsonSheetRow {
     if (typeof column.value === "function") {
       jsonSheetRow[column.label] = column.value(content)
     } else {
-      jsonSheetRow[column.label] = content[column.value]
+      jsonSheetRow[column.label] = getContentProperty(content, column.value)
     }
   })
   return jsonSheetRow

--- a/index.ts
+++ b/index.ts
@@ -102,7 +102,8 @@ function xlsx(jsonSheets: IJsonSheet[], settings: ISettings = {}): Buffer | unde
 }
 
 export default xlsx
-export {getContentProperty, getJsonSheetRow}
+export {getContentProperty, getJsonSheetRow, getWorksheetColumnWidths}
 module.exports = xlsx
 module.exports.getContentProperty = getContentProperty
 module.exports.getJsonSheetRow = getJsonSheetRow
+module.exports.getWorksheetColumnWidths = getWorksheetColumnWidths

--- a/index.ts
+++ b/index.ts
@@ -63,6 +63,11 @@ function writeWorkbook(workbook: WorkBook, settings: ISettings = {}): Buffer | u
 }
 
 function xlsx(data: IJsonSheet[], settings: ISettings = {}): Buffer | undefined {
+
+  if (!data.length) {
+    return
+  }
+
   const wb = utils.book_new() // Creating a workbook, this is the name given to an Excel file
   data.forEach((actualSheet, actualIndex) => {
     const newSheet = getWorksheet(actualSheet, settings)

--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import {utils, WorkSheet, write, writeFile} from 'xlsx'
+import {utils, WorkBook, WorkSheet, write, writeFile} from 'xlsx'
 import {IColumn, IContent, IJsonSheet, IJsonSheetRow, ISettings, IWorksheetColumnWidth} from './types'
 
 function getJsonSheetRow(content: IContent, columns: IColumn[]): IJsonSheetRow {
@@ -53,14 +53,22 @@ function getWorksheet(jsonSheet: IJsonSheet, settings: ISettings): WorkSheet {
   return worksheet
 }
 
+function writeWorkbook(workbook: WorkBook, settings: ISettings = {}): Buffer | undefined {
+
+  const filename = `${settings.fileName ?? 'Spreadsheet'}.xlsx`
+  const writeOptions = settings.writeOptions ?? {}
+
+  return writeOptions.type === 'buffer' ? write(workbook, writeOptions)
+    : writeFile(workbook, filename, writeOptions)
+}
+
 function xlsx(data: IJsonSheet[], settings: ISettings = {}): Buffer | undefined {
-  const writeOptions = settings.writeOptions === undefined ? {} : settings.writeOptions
   const wb = utils.book_new() // Creating a workbook, this is the name given to an Excel file
   data.forEach((actualSheet, actualIndex) => {
     const newSheet = getWorksheet(actualSheet, settings)
     utils.book_append_sheet(wb, newSheet, `${actualSheet.sheet ?? `Sheet ${actualIndex + 1}`}`) // Add Worksheet to Workbook
   })
-  return writeOptions.type === 'buffer' ? write(wb, writeOptions) : writeFile(wb, `${settings.fileName ?? 'Spreadsheet'}.xlsx`, writeOptions)
+  return writeWorkbook(wb, settings)
 }
 
 export default xlsx

--- a/index.ts
+++ b/index.ts
@@ -1,5 +1,5 @@
 import { utils, write, writeFile } from 'xlsx'
-import { IColumns, IData, ISettings } from './types/index'
+import { IColumn, IData, ISettings } from './types/index'
 
 module.exports = (data: IData[], settings: ISettings = {}) => {
   const extraLength = settings.extraLength === undefined ? 1 : settings.extraLength
@@ -10,7 +10,7 @@ module.exports = (data: IData[], settings: ISettings = {}) => {
     const excelIndexes: string[] = []
     actualSheet.content.forEach((el1: any) => { // creating new excel data array
       const obj: any = {}
-      actualSheet.columns.forEach((el2: IColumns) => {
+      actualSheet.columns.forEach((el2: IColumn) => {
         const val = (typeof el2.value === 'function' ? el2.value(el1) : el1[el2.value]) // If is a function execute it, if not just enter the value
         obj[el2.label] = val
       })

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,5 @@
+/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+};

--- a/package.json
+++ b/package.json
@@ -12,15 +12,19 @@
     "start-client": "vue-cli-service serve",
     "build-client": "vue-cli-service build",
     "start-server": "nodemon server.js",
-    "lint": "ts-standard --fix"
+    "lint": "ts-standard --fix",
+    "test": "jest"
   },
   "dependencies": {
     "xlsx": "^0.17.2"
   },
   "devDependencies": {
+    "@types/jest": "^27.0.2",
     "@types/node": "^16.10.2",
     "@vue/cli-service": "^4.5.13",
     "express": "^4.17.1",
+    "jest": "^27.3.1",
+    "ts-jest": "^27.0.7",
     "typescript": "^4.4.3",
     "uglify-js": "^3.14.2",
     "vue": "^2.6.14",

--- a/tests/contentProperty.test.ts
+++ b/tests/contentProperty.test.ts
@@ -1,0 +1,65 @@
+import {getContentProperty} from '../index'
+
+test("Should access first level property", () => {
+
+  const supportTicket = {
+    id: "e4te583nbt",
+    title: "Problem with server",
+    user: "daniel31"
+  }
+
+  expect(getContentProperty(supportTicket, "user"))
+    .toBe("daniel31")
+
+  expect(getContentProperty(supportTicket, "description"))
+    .toBe("")
+})
+
+test("Should access second level property", () => {
+
+  const employee = {
+    name: "Sophie",
+    age: "21",
+    email: {
+      work: "sophiedev@job.com",
+      personal: "sophie@email.com"
+    }
+  }
+
+  expect(getContentProperty(employee, "email.work"))
+    .toBe("sophiedev@job.com")
+
+  expect(getContentProperty(employee, "email.personal"))
+    .toBe("sophie@email.com")
+
+  expect(getContentProperty(employee, "email.business"))
+    .toBe("")
+})
+
+test("Should access third level property", () => {
+
+  const purchase = {
+    id: "934as44951",
+    costumer: {
+      email: "jeniffer@email.com",
+      phoneNumber: "44444444",
+      billingAddress: {
+        line1: "123 Street",
+        city: "Montreal",
+        postalCode: 55555
+      }
+    }
+  }
+
+  expect(getContentProperty(purchase, "costumer.billingAddress.line1"))
+    .toBe("123 Street")
+
+  expect(getContentProperty(purchase, "costumer.billingAddress.city"))
+    .toBe("Montreal")
+
+  expect(getContentProperty(purchase, "costumer.billingAddress.postalCode"))
+    .toBe(55555)
+
+  expect(getContentProperty(purchase, "costumer.billingAddress.countryCode"))
+    .toBe("")
+})

--- a/tests/getJsonSheetRow.test.ts
+++ b/tests/getJsonSheetRow.test.ts
@@ -1,0 +1,72 @@
+import {IContent} from '../types'
+import {getJsonSheetRow} from '../index'
+
+test("", () => {
+
+  const track = {
+    id: "4ase432i",
+    name: "Help",
+    artist: "Galantis",
+    album: {
+      id: "532o48sn3",
+      name: "Help",
+      albumType: "single",
+      totalTracks: 1,
+      releaseDate: "2014-03-11"
+    },
+    explicit: false,
+    popularity: 21,
+    durationMs: 4010
+  }
+
+  expect(getJsonSheetRow(track, [
+    {label: "ID", value: "id"}
+  ]))
+    .toEqual({"ID": "4ase432i"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Name", value: "name"}
+  ]))
+    .toEqual({"Name": "Help"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Artist", value: "artist"}
+  ]))
+    .toEqual({"Artist": "Galantis"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Album", value: "album.name"}
+  ]))
+    .toEqual({"Album": "Help"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Explicit content", value: (content: IContent) => {return content.explicit ? "Yes" : "No"}}
+  ]))
+    .toEqual({"Explicit content": "No"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Popularity", value: "popularity"}
+  ]))
+    .toEqual({"Popularity": 21})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Duration", value: (content: IContent) => {return (content.durationMs as number)/1000 + "s"}}
+  ]))
+    .toEqual({"Duration": "4.01s"})
+
+  expect(getJsonSheetRow(track, [
+    {label: "URI", value: "uri"}
+  ]))
+    .toEqual({"URI": ""})
+
+  expect(getJsonSheetRow(track, [
+    {label: "Album", value: "album"}
+  ]))
+    .toEqual({"Album": {
+        id: "532o48sn3",
+        name: "Help",
+        albumType: "single",
+        totalTracks: 1,
+        releaseDate: "2014-03-11"
+      }})
+})

--- a/tests/getWorksheetColumWidths.test.ts
+++ b/tests/getWorksheetColumWidths.test.ts
@@ -1,0 +1,40 @@
+import {utils} from 'xlsx'
+import {getJsonSheetRow, getWorksheetColumnWidths} from '../index'
+
+test("Should return only one column width", () => {
+
+  const content = {username: "art3mis"}
+  const columns = [{label: "Username", value: "username"}]
+
+  const jsonSheetRow = getJsonSheetRow(content, columns)
+  const worksheet = utils.json_to_sheet([jsonSheetRow])
+
+  // Column label is larger than content
+  expect(getWorksheetColumnWidths(worksheet))
+    .toEqual([{width: 9}])
+
+  expect(getWorksheetColumnWidths(worksheet, 0))
+    .toEqual([{width: 8}])
+
+  expect(getWorksheetColumnWidths(worksheet, 4))
+    .toEqual([{width: 12}])
+})
+
+test("Should return two column widths", () => {
+
+  const content = {name: "Interstellar", year: 2014}
+  const columns = [{label: "Movie", value: "name"}, {label: "Year", value: "year"}]
+
+  const jsonSheetRow = getJsonSheetRow(content, columns)
+  const worksheet = utils.json_to_sheet([jsonSheetRow])
+
+  // Content is larger than column label
+  expect(getWorksheetColumnWidths(worksheet))
+    .toEqual([{width: 13}, {width: 5}])
+
+  expect(getWorksheetColumnWidths(worksheet, 0))
+    .toEqual([{width: 12}, {width: 4}])
+
+  expect(getWorksheetColumnWidths(worksheet, 4))
+    .toEqual([{width: 16}, {width: 8}])
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,0 +1,56 @@
+import jsonAsXlsx from '../index'
+import {IJsonSheet} from '../types'
+
+test("JsonAsXlsx should return undefined on empty data array", () => {
+
+  expect(jsonAsXlsx([], { writeOptions: {type: "buffer"}}))
+    .toBeUndefined()
+})
+
+test("JsonAsXlsx should return xlsx buffer even without worksheet name", () => {
+
+  const worksheet: IJsonSheet = {
+    columns: [{label: "Name", value: "name"}],
+    content: [{name: "Joseph"}]
+  }
+
+  //TODO: Verify buffer content
+  expect(jsonAsXlsx([worksheet], {writeOptions: {type: "buffer"}}))
+    .toBeInstanceOf(Buffer)
+})
+
+test("JsonAsXlsx should return undefined on xlsx file creation", () => {
+
+  const worksheet: IJsonSheet = {
+    sheet: "Friends",
+    columns: [
+      {label: "Name", value: "name"}
+    ],
+    content: [
+      {name: "Andreas", username: "andr34s"}
+    ]
+  }
+
+  //TODO: Verify that file was written
+  expect(jsonAsXlsx([worksheet])).toBeUndefined()
+})
+
+test('JsonAsXlsx should return xlsx buffer for worksheet with name', () => {
+
+  const data: IJsonSheet[] = [{
+    sheet: 'Adults',
+    columns: [
+      {label: 'User', value: 'user'}, // Top level data
+      {label: 'Age', value: (row: any) => (row.age + ' years')}, // Run functions
+      {label: 'Phone', value: (row: any) => (row.more ? row.more.phone || '' : '')}, // Deep props
+    ],
+    content: [
+      {user: 'Andrea', age: 20, more: {phone: '11111111'}},
+      {user: 'Luis', age: 21, more: {phone: '12345678'}}
+    ]
+  }]
+
+  //TODO: Verify buffer content
+  expect(jsonAsXlsx(data, {writeOptions: {type: "buffer"}}))
+    .toBeInstanceOf(Buffer)
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -10,7 +10,7 @@ export interface IContent {
 }
 
 export interface IJsonSheet {
-  sheet: string
+  sheet?: string
   columns: [IColumn, ...IColumn[]]
   content: [IContent, ...IContent[]]
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,11 +1,11 @@
-export interface IColumns {
+export interface IColumn {
   label: string
   value: string | Function
 }
 
 export interface IData {
   sheet: string
-  columns: IColumns[]
+  columns: IColumn[]
   content: any[]
 }
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -20,3 +20,7 @@ export interface ISettings {
   fileName?: string
   writeOptions?: WritingOptions
 }
+
+export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings): Buffer | undefined
+
+export default xlsx

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,10 +3,14 @@ export interface IColumn {
   value: string | Function
 }
 
+export interface IContent {
+  [key: string]: string | number | boolean | object
+}
+
 export interface IData {
   sheet: string
   columns: IColumn[]
-  content: any[]
+  content: IContent[]
 }
 
 export interface ISettings {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -9,7 +9,7 @@ export interface IContent {
   [key: string]: string | number | boolean | object
 }
 
-export interface IData {
+export interface IJsonSheet {
   sheet: string
   columns: IColumn[]
   content: IContent[]

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -25,6 +25,10 @@ export interface IJsonSheetRow {
   [key: string]: string | number | boolean | object
 }
 
+export interface IWorksheetColumnWidth {
+  width: number
+}
+
 export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings): Buffer | undefined
 
 export default xlsx

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,3 +1,5 @@
+import {WritingOptions} from 'xlsx'
+
 export interface IColumn {
   label: string
   value: string | ((value: IContent) => string | number | boolean | object)
@@ -16,5 +18,5 @@ export interface IData {
 export interface ISettings {
   extraLength?: number
   fileName?: string
-  writeOptions?: any
+  writeOptions?: WritingOptions
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -21,6 +21,10 @@ export interface ISettings {
   writeOptions?: WritingOptions
 }
 
+export interface IJsonSheetRow {
+  [key: string]: string | number | boolean | object
+}
+
 export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings): Buffer | undefined
 
 export default xlsx

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -2,11 +2,11 @@ import {WritingOptions} from 'xlsx'
 
 export interface IColumn {
   label: string
-  value: string | ((value: IContent) => string | number | boolean | object)
+  value: string | ((value: IContent) => string | number | boolean | Date | IContent)
 }
 
 export interface IContent {
-  [key: string]: string | number | boolean | object
+  [key: string]: string | number | boolean | Date | IContent
 }
 
 export interface IJsonSheet {
@@ -22,7 +22,7 @@ export interface ISettings {
 }
 
 export interface IJsonSheetRow {
-  [key: string]: string | number | boolean | object
+  [key: string]: string | number | boolean | Date | IContent
 }
 
 export interface IWorksheetColumnWidth {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,6 +1,6 @@
 export interface IColumn {
   label: string
-  value: string | Function
+  value: string | ((value: IContent) => string | number | boolean | object)
 }
 
 export interface IContent {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,8 +11,8 @@ export interface IContent {
 
 export interface IJsonSheet {
   sheet: string
-  columns: IColumn[]
-  content: IContent[]
+  columns: [IColumn, ...IColumn[]]
+  content: [IContent, ...IContent[]]
 }
 
 export interface ISettings {


### PR DESCRIPTION
Hii 😋 

I tried using this package in typescript but it didn't have types, later I checked the issues tab and I saw that you've recently added some of them! And I thought that I could help (:

The main idea I had, was to avoid "any" as much as possible and that later took me into dividing it into functions. 

With the tests I've done, it works as before. The only problem that I've found is that **npm run build** creates an index.js file that only contains type definitions.

Running only **tsc** works okay, the problem I think is **uglifiyjs** but I didn't want to modify it. Maybe you can check it 😄 

The other thing is that, with commit e9b7ea4ce5d47ef644619b840a2c98350ff048f9 columns and content can't be empty. Which is a nice thing but it requires to specify the type of the variable.

Right now, this is invalid because it fails to match the type.
```js
const jsonSheets = [{
  sheet: "Friends",
  columns: [
    {label: "Name", value: "name"}
  ],
  content: [
    {name: "Andreas", username: "andr34s"}
  ]
}]

xlsx(jsonSheets)
```

This is the way it should be used and we would need to update the README. 
```js
const jsonSheets: IJsonSheet[] = [{
  sheet: "Friends",
  columns: [
    {label: "Name", value: "name"}
  ],
  content: [
    {name: "Andreas", username: "andr34s"}
  ]
}]

xlsx(jsonSheets)
```

That's it, let me know what you think on this 😆 