### PR TITLE
Allow IContent[] to be empty and return an xlsx file with only column labels in that case

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -59,9 +59,16 @@ function getWorksheetColumnWidths (worksheet: WorkSheet, extraLength: number = 1
 }
 
 function getWorksheet (jsonSheet: IJsonSheet, settings: ISettings): WorkSheet {
-  const jsonSheetRows = jsonSheet.content.map((contentItem) => {
-    return getJsonSheetRow(contentItem, jsonSheet.columns)
-  })
+  let jsonSheetRows: IJsonSheetRow[]
+
+  if (jsonSheet.content.length > 0) {
+    jsonSheetRows = jsonSheet.content.map((contentItem) => {
+      return getJsonSheetRow(contentItem, jsonSheet.columns)
+    })
+  } else {
+    // If there's no content, show only column labels
+    jsonSheetRows = jsonSheet.columns.map((column) => ({ [column.label]: '' }))
+  }
 
   const worksheet = utils.json_to_sheet(jsonSheetRows)
   worksheet['!cols'] = getWorksheetColumnWidths(worksheet, settings.extraLength)

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -6,6 +6,16 @@ test('JsonAsXlsx should return undefined on empty data array', () => {
     .toBeUndefined()
 })
 
+test('JsonAsXlsx should return xlsx with only column labels on empty content array', () => {
+  const jsonSheet: IJsonSheet = {
+    columns: [{ label: 'Username', value: 'username' }, { label: 'Playing', value: 'activity.game' }],
+    content: []
+  }
+
+  expect(jsonAsXlsx([jsonSheet], { writeOptions: { type: 'buffer' } }))
+    .toBeInstanceOf(Buffer)
+})
+
 test('JsonAsXlsx should return xlsx buffer even without worksheet name', () => {
   const worksheet: IJsonSheet = {
     columns: [{ label: 'Name', value: 'name' }],

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -11,8 +11,8 @@ export interface IContent {
 
 export interface IJsonSheet {
   sheet?: string
-  columns: [IColumn, ...IColumn[]]
-  content: [IContent, ...IContent[]]
+  columns: IColumn[]
+  content: IContent[]
 }
 
 export interface ISettings {


### PR DESCRIPTION
Fixes #23 

This is an edge case that I didn't think about 😅 but it makes a lot of sense to have it

There is also the edge case where IColumn[] is empty (still not solved), but I think that in that case, we should try to fail as soon as possible. 🤔 