### PR TITLE
Unit test json-as-xlsx using xlsx buffers

### DIFF
--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { read as readBufferWorkBook } from 'xlsx';
 import jsonxlsx from '../index';
-import { IJsonSheet, ISettings } from '../types';
+import { IContent, IJsonSheet, ISettings } from '../types';
 
 describe('json-as-xlsx', () => {
   it('should return undefined if sheets array is empty', () => {
@@ -96,6 +96,29 @@ describe('json-as-xlsx', () => {
       expect(workSheet['A1'].v).toBe('IP');
       expect(workSheet['A2'].v).toBe('0.0.0.0');
       expect(workSheet['A3'].v).toBe('0.0.0.1');
+    });
+
+    it('should handle function column value', () => {
+      const maskPhoneNumber = (cell: IContent) =>
+        new String(cell.phone).replace(/^(\d{3})(\d{4}).*/, '$1-$2');
+
+      const sheets = [
+        {
+          sheet: 'Users',
+          columns: [{ label: 'Phone', value: maskPhoneNumber }],
+          content: [
+            { name: 'Martin', phone: '1234567' },
+            { name: 'Robert', phone: '1234568' },
+          ],
+        },
+      ];
+      const buffer = jsonxlsx(sheets, settings);
+      const workBook = readBufferWorkBook(buffer);
+      const workSheet = workBook.Sheets['Users'];
+
+      expect(workSheet['A1'].v).toBe('Phone');
+      expect(workSheet['A2'].v).toBe('123-4567');
+      expect(workSheet['A3'].v).toBe('123-4568');
     });
 
     it('should handle multiple sheets', () => {

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,20 +1,20 @@
-import { read as readBufferWorkBook } from 'xlsx';
-import jsonxlsx from '../index';
-import { IContent, IJsonSheet, ISettings } from '../types';
+import { read as readBufferWorkBook } from 'xlsx'
+import jsonxlsx from '../index'
+import { IContent, IJsonSheet, ISettings } from '../types'
 
 describe('json-as-xlsx', () => {
   it('should return undefined if sheets array is empty', () => {
-    const sheets: IJsonSheet[] = [];
-    const result = jsonxlsx(sheets);
-    expect(result).toBeUndefined();
-  });
+    const sheets: IJsonSheet[] = []
+    const result = jsonxlsx(sheets)
+    expect(result).toBeUndefined()
+  })
 
   describe('writeOptions.type is set to buffer', () => {
     const settings: ISettings = {
       writeOptions: {
         type: 'buffer',
       },
-    };
+    }
 
     it('should return buffer', () => {
       const sheets = [
@@ -22,10 +22,10 @@ describe('json-as-xlsx', () => {
           columns: [{ label: 'Name', value: 'name' }],
           content: [{ name: 'Martin' }],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      expect(buffer).toBeInstanceOf(Buffer);
-    });
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      expect(buffer).toBeInstanceOf(Buffer)
+    })
 
     it('should return parsable xlsx buffer', () => {
       const sheets = [
@@ -33,12 +33,12 @@ describe('json-as-xlsx', () => {
           columns: [{ label: 'Name', value: 'name' }],
           content: [{ name: 'Martin' }],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
 
-      expect(workBook).toBeDefined();
-    });
+      expect(workBook).toBeDefined()
+    })
 
     it('should return one column filled cells', () => {
       const sheets = [
@@ -47,19 +47,19 @@ describe('json-as-xlsx', () => {
           columns: [{ label: 'Name', value: 'name' }],
           content: [{ name: 'Martin' }, { name: 'Kent' }],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
-      const workSheet = workBook.Sheets['Authors'];
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets['Authors']
 
-      expect(workSheet['!ref']).toBe('A1:A3');
-      expect(workSheet['A1'].v).toBe('Name');
-      expect(workSheet['A2'].v).toBe('Martin');
-      expect(workSheet['A3'].v).toBe('Kent');
-    });
+      expect(workSheet['!ref']).toBe('A1:A3')
+      expect(workSheet['A1'].v).toBe('Name')
+      expect(workSheet['A2'].v).toBe('Martin')
+      expect(workSheet['A3'].v).toBe('Kent')
+    })
 
     it('should return only the column headers if there is no content', () => {
-      const sheetName = 'Authors';
+      const sheetName = 'Authors'
       const sheets = [
         {
           sheet: sheetName,
@@ -69,14 +69,14 @@ describe('json-as-xlsx', () => {
           ],
           content: [],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
-      const workSheet = workBook.Sheets[sheetName];
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets[sheetName]
 
-      expect(workSheet['A1'].v).toBe('Name');
-      expect(workSheet['B1'].v).toBe('Age');
-    });
+      expect(workSheet['A1'].v).toBe('Name')
+      expect(workSheet['B1'].v).toBe('Age')
+    })
 
     it('should handle deep props', () => {
       const sheets = [
@@ -88,19 +88,19 @@ describe('json-as-xlsx', () => {
             { name: 'Robert', metadata: { ip: '0.0.0.1' } },
           ],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
-      const workSheet = workBook.Sheets['Users'];
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets['Users']
 
-      expect(workSheet['A1'].v).toBe('IP');
-      expect(workSheet['A2'].v).toBe('0.0.0.0');
-      expect(workSheet['A3'].v).toBe('0.0.0.1');
-    });
+      expect(workSheet['A1'].v).toBe('IP')
+      expect(workSheet['A2'].v).toBe('0.0.0.0')
+      expect(workSheet['A3'].v).toBe('0.0.0.1')
+    })
 
     it('should handle function column value', () => {
       const maskPhoneNumber = (cell: IContent) =>
-        new String(cell.phone).replace(/^(\d{3})(\d{4}).*/, '$1-$2');
+        new String(cell.phone).replace(/^(\d{3})(\d{4}).*/, '$1-$2')
 
       const sheets = [
         {
@@ -111,28 +111,28 @@ describe('json-as-xlsx', () => {
             { name: 'Robert', phone: '1234568' },
           ],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
-      const workSheet = workBook.Sheets['Users'];
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets['Users']
 
-      expect(workSheet['A1'].v).toBe('Phone number');
-      expect(workSheet['A2'].v).toBe('123-4567');
-      expect(workSheet['A3'].v).toBe('123-4568');
-    });
+      expect(workSheet['A1'].v).toBe('Phone number')
+      expect(workSheet['A2'].v).toBe('123-4567')
+      expect(workSheet['A3'].v).toBe('123-4568')
+    })
 
     it('should call optional callback', () => {
-      const callback = jest.fn();
+      const callback = jest.fn()
       const sheets = [
         {
           columns: [{ label: 'Name', value: 'name' }],
           content: [{ name: 'Martin' }],
         },
-      ];
-      jsonxlsx(sheets, settings, callback);
+      ]
+      jsonxlsx(sheets, settings, callback)
 
-      expect(callback).toBeCalledTimes(1);
-    });
+      expect(callback).toBeCalledTimes(1)
+    })
 
     it('should handle multiple sheets', () => {
       const sheets = [
@@ -159,30 +159,30 @@ describe('json-as-xlsx', () => {
             { title: 'Git', author: 'Robert' },
           ],
         },
-      ];
-      const buffer = jsonxlsx(sheets, settings);
-      const workBook = readBufferWorkBook(buffer);
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
 
-      const authorsSheet = workBook.Sheets['Authors'];
-      const booksSheet = workBook.Sheets['Books'];
+      const authorsSheet = workBook.Sheets['Authors']
+      const booksSheet = workBook.Sheets['Books']
 
-      expect(workBook.SheetNames).toEqual(['Authors', 'Books']);
+      expect(workBook.SheetNames).toEqual(['Authors', 'Books'])
 
-      expect(authorsSheet['A1'].v).toBe('Name');
-      expect(authorsSheet['B1'].v).toBe('Age');
-      expect(authorsSheet['A2'].v).toBe('Martin');
-      expect(authorsSheet['B2'].v).toBe(50);
-      expect(authorsSheet['A3'].v).toBe('Robert');
-      expect(authorsSheet['B3'].v).toBe(20);
-      expect(authorsSheet['A4'].v).toBe('Andrea');
-      expect(authorsSheet['B4'].v).toBe(35);
+      expect(authorsSheet['A1'].v).toBe('Name')
+      expect(authorsSheet['B1'].v).toBe('Age')
+      expect(authorsSheet['A2'].v).toBe('Martin')
+      expect(authorsSheet['B2'].v).toBe(50)
+      expect(authorsSheet['A3'].v).toBe('Robert')
+      expect(authorsSheet['B3'].v).toBe(20)
+      expect(authorsSheet['A4'].v).toBe('Andrea')
+      expect(authorsSheet['B4'].v).toBe(35)
 
-      expect(booksSheet['A1'].v).toBe('Title');
-      expect(booksSheet['B1'].v).toBe('Author');
-      expect(booksSheet['A2'].v).toBe('TDD');
-      expect(booksSheet['B2'].v).toBe('Martin');
-      expect(booksSheet['A3'].v).toBe('Git');
-      expect(booksSheet['B3'].v).toBe('Robert');
-    });
-  });
-});
+      expect(booksSheet['A1'].v).toBe('Title')
+      expect(booksSheet['B1'].v).toBe('Author')
+      expect(booksSheet['A2'].v).toBe('TDD')
+      expect(booksSheet['B2'].v).toBe('Martin')
+      expect(booksSheet['A3'].v).toBe('Git')
+      expect(booksSheet['B3'].v).toBe('Robert')
+    })
+  })
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -105,7 +105,7 @@ describe('json-as-xlsx', () => {
       const sheets = [
         {
           sheet: 'Users',
-          columns: [{ label: 'Phone', value: maskPhoneNumber }],
+          columns: [{ label: 'Phone number', value: maskPhoneNumber }],
           content: [
             { name: 'Martin', phone: '1234567' },
             { name: 'Robert', phone: '1234568' },
@@ -116,9 +116,22 @@ describe('json-as-xlsx', () => {
       const workBook = readBufferWorkBook(buffer);
       const workSheet = workBook.Sheets['Users'];
 
-      expect(workSheet['A1'].v).toBe('Phone');
+      expect(workSheet['A1'].v).toBe('Phone number');
       expect(workSheet['A2'].v).toBe('123-4567');
       expect(workSheet['A3'].v).toBe('123-4568');
+    });
+
+    it('should call optional callback', () => {
+      const callback = jest.fn();
+      const sheets = [
+        {
+          columns: [{ label: 'Name', value: 'name' }],
+          content: [{ name: 'Martin' }],
+        },
+      ];
+      jsonxlsx(sheets, settings, callback);
+
+      expect(callback).toBeCalledTimes(1);
     });
 
     it('should handle multiple sheets', () => {


### PR DESCRIPTION
## Description

Increase unit testing for future refactoring or new features.

## How?

- Use `writeOptions.type: 'buffer'` workbook settings.
- Parse the returned buffer using the `XLSX.read` utility to assert the content of the buffer:
  - The sheet's cells values, ranges, and names.
