### PR TITLE
Set package.json main to src/index.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "json-as-xlsx",
   "version": "2.3.9",
-  "main": "src/index.ts",
+  "main": "src/index.js",
   "license": "MIT",
   "types": "types/index.d.ts",
   "description": "Create excel xlsx file from json",


### PR DESCRIPTION
Unfortunately, https://github.com/LuisEnMarroquin/json-as-xlsx/pull/29 introduced a bug, my bad. It's not possible to use the package in JavaScript only in TypeScript.

Can be reproduced [here](https://codesandbox.io/s/black-paper-v242r?file=/src/index.js).
