### PR TITLE
Add support for column formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,12 @@ let data = [
     sheet: 'Children',
     columns: [
       { label: 'User', value: 'user' }, // Top level data
-      { label: 'Age', value: row => (row.age + ' years') }, // Run functions
-      { label: 'Phone', value: 'user.more.phone' }, // Deep props
+      { label: 'Age', value: 'age', format: '# "años"' }, // Column format
+      { label: 'Phone', value: 'user.more.phone', format: "(###) ###-####" }, // Deep props and column format
     ],
     content: [
-      { user: 'Manuel', age: 16, more: { phone: '99999999' } },
-      { user: 'Ana', age: 17, more: { phone: '87654321' } }
+      { user: 'Manuel', age: 16, more: { phone: 9999999900 } },
+      { user: 'Ana', age: 17, more: { phone: 8765432135 } }
     ]
   }
 ]
@@ -56,6 +56,42 @@ let callback = function(sheet) {
 }
 
 xlsx(data, settings, callback) // Will download the excel file
+```
+
+### Column formatting
+
+> **Note:** Cell formatting is type based, i.e. the format type and value type must match.
+>
+> If you want to use a Date format, the value must be of type Date; if you want a number format, the value must be a Number.
+
+Column formatting can be provided in the column object, i.e.
+
+```js
+columns: [
+   { label: 'Income', value: 'income', format: '\€#,##0.00' },
+]
+```
+
+- A list of SheetJS format examples can be found
+  here: [SSF library](https://github.com/SheetJS/sheetjs/blob/f443aa8475ebf051fc4e888cf0a6c3e5b751813c/bits/10_ssf.js#L42)
+- ECMA-376 number formatting
+  specification:  [Number formats](https://c-rex.net/projects/samples/ooxml/e1/Part4/OOXML_P4_DOCX_numFmts_topic_ID0E6KK6.html)
+
+Examples
+
+```js
+// Number formats
+
+'$0.00'         // Basic
+'\£#,##0.00'    // Pound
+'0%'            // Percentage
+'#.# "ft"'      // Number and text
+
+// Date formats
+'d-mmm-yy'      // 12-Mar-22
+'ddd'           // (eg. Sat)
+'dddd'          // (eg. Saturday)
+'h:mm AM/PM'    // 1:10 PM
 ```
 
 ## Examples

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,13 +95,23 @@ const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: number = 1)
       return cell.charAt(0) === column || cell.slice(0, 2) === column
     })
 
-    const maxWidthCell = columnCells.reduce((previousCell, currentCell) => {
-      return worksheet[previousCell].v.length > worksheet[currentCell].v.length
-        ? previousCell
-        : currentCell
-    })
+    const maxWidthCell = columnCells.reduce((maxWidth, cellId) => {
+      const cell = worksheet[cellId]
 
-    return { width: worksheet[maxWidthCell].v.length as number + extraLength }
+      const cellContentLength: number = getObjectLength(cell.v)
+
+      if (!cell.z) {
+        return Math.max(maxWidth, cellContentLength)
+      }
+
+      const cellFormatLength: number = cell.z.length
+
+      const largestWidth: number = Math.max(cellContentLength, cellFormatLength)
+
+      return Math.max(maxWidth, largestWidth)
+    }, 0)
+
+    return { width: maxWidthCell + extraLength }
   })
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,15 +33,21 @@ const getJsonSheetRow = (content: IContent, columns: IColumn[]): IJsonSheetRow =
   return jsonSheetRow
 }
 
-const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: number = 1): IWorksheetColumnWidth[] => {
+const getWorksheetColumnIds = (worksheet: WorkSheet): string[] => {
   const columnRange = utils.decode_range(worksheet['!ref'] ?? '')
 
   // Column letters present in the workbook, e.g. A, B, C
-  const columnLetters: string[] = []
+  const columnIds: string[] = []
   for (let C = columnRange.s.c; C <= columnRange.e.c; C++) {
     const address = utils.encode_col(C)
-    columnLetters.push(address)
+    columnIds.push(address)
   }
+
+  return columnIds
+}
+
+const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: number = 1): IWorksheetColumnWidth[] => {
+  const columnLetters: string[] = getWorksheetColumnIds(worksheet)
 
   return columnLetters.map((column) => {
     // Cells that belong to this column

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,6 +46,22 @@ const getWorksheetColumnIds = (worksheet: WorkSheet): string[] => {
   return columnIds
 }
 
+const getObjectLength = (object: unknown): number => {
+    if (typeof object === 'string') {
+        return object.length
+    }
+    if (typeof object === 'number') {
+        return object.toString().length
+    }
+    if (typeof object === 'boolean') {
+        return object ? 'true'.length : 'false'.length
+    }
+    if (object instanceof Date) {
+        return object.toString().length
+    }
+    return 0
+}
+
 const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: number = 1): IWorksheetColumnWidth[] => {
   const columnLetters: string[] = getWorksheetColumnIds(worksheet)
 

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,6 +3,7 @@ import { WritingOptions } from 'xlsx'
 export interface IColumn {
   label: string
   value: string | ((value: IContent) => string | number | boolean | Date | IContent)
+  format?: string
 }
 
 export interface IContent {


### PR DESCRIPTION
Hi ! 🐞 

I've added the feature of specifying the format of columns. 😄  

It's optional by default, but the user can start using it just by passing the format string in the column object:

```js
const jsonSheets: IJsonSheet[] = [
    {
        columns: [
            {label: 'Title', value: 'name'},
            {label: 'Duration', value: 'durationMs', format: '#.# "seconds"'},
            {label: 'Popularity', value: 'popularity', format: '# "points"'},
        ],
        content: [
            {
                name: 'Help',
                artist: 'Galantis',
                album: {
                    id: '532o48sn3',
                    name: 'Help',
                    albumType: 'single',
                    totalTracks: 1,
                    releaseDate: '2014-03-11'
                },
                explicit: false,
                popularity: 21,
                durationMs: 4010
            }
        ]
    }
]
xlsx(jsonSheets)
```

Screenshot:
![image](https://user-images.githubusercontent.com/26639800/158034253-3aef6115-c3e5-4813-b92a-bb8d5401a393.png)

Closes #37