### PR TITLE
Add callback type to xlsx signature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { utils, WorkBook, WorkSheet, write, writeFile } from "xlsx/dist/xlsx.mini.min"
-import { IColumn, IContent, IJsonSheet, IJsonSheetRow, ISettings, IWorksheetColumnWidth } from "../types/index"
+import { IColumn, IContent, IJsonSheet, IJsonSheetRow, ISettings, IWorkbookCallback, IWorksheetColumnWidth } from "../types/index"
 
 const getContentProperty = (content: IContent, property: string): string | number | boolean | Date | IContent => {
   const accessContentProperties = (content: IContent, properties: string[]): string | number | boolean | Date | IContent => {
@@ -142,8 +142,6 @@ const writeWorkbook = (workbook: WorkBook, settings: ISettings = {}): Buffer | u
 
   return writeOptions.type === "buffer" ? write(workbook, writeOptions) : writeFile(workbook, filename, writeOptions)
 }
-
-type IWorkbookCallback = (workbook: WorkBook) => void
 
 const xlsx = (jsonSheets: IJsonSheet[], settings: ISettings = {}, workbookCallback: IWorkbookCallback = () => {}): Buffer | undefined => {
   if (jsonSheets.length === 0) return

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,7 +159,9 @@ const xlsx = (jsonSheets: IJsonSheet[], settings: ISettings = {}, workbookCallba
 
 export default xlsx
 export { getContentProperty, getJsonSheetRow, getWorksheetColumnWidths }
+export { utils }
 module.exports = xlsx
 module.exports.getContentProperty = getContentProperty
 module.exports.getJsonSheetRow = getJsonSheetRow
 module.exports.getWorksheetColumnWidths = getWorksheetColumnWidths
+module.exports.utils = utils

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,5 +1,5 @@
 import { WritingOptions } from "xlsx"
-import { WorkBook } from 'xlsx/dist/xlsx.mini.min'
+import { utils, WorkBook, WorkSheet } from 'xlsx/dist/xlsx.mini.min'
 
 export interface IColumn {
   label: string
@@ -36,3 +36,4 @@ export type IWorkbookCallback = (workbook: WorkBook) => void
 export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings, callback?: IWorkbookCallback): Buffer | undefined
 
 export default xlsx
+export { utils, WorkBook, WorkSheet }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,4 +1,5 @@
 import { WritingOptions } from "xlsx"
+import { WorkBook } from 'xlsx/dist/xlsx.mini.min'
 
 export interface IColumn {
   label: string
@@ -30,6 +31,8 @@ export interface IWorksheetColumnWidth {
   width: number
 }
 
-export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings): Buffer | undefined
+export type IWorkbookCallback = (workbook: WorkBook) => void
+
+export function xlsx(jsonSheets: IJsonSheet[], settings?: ISettings, callback?: IWorkbookCallback): Buffer | undefined
 
 export default xlsx


### PR DESCRIPTION
Hi again 🐞 😄 

Today I was using the callback that we added a while ago, and I noticed that we forgot to add its types 🐞 

To make it more functional, I've also exposed the interfaces `WorkBook` and `WorkSheet` and the `utils` function from **xlsx**, so we can import them and use them in our callback.
