### PR TITLE
fix: append `null` type under `IContent`

### DIFF
--- a/packages/main-library/src/index.ts
+++ b/packages/main-library/src/index.ts
@@ -7,7 +7,7 @@ export interface IColumn {
 }
 
 export interface IContent {
-  [key: string]: string | number | boolean | Date | IContent
+  [key: string]: string | number | boolean | Date | IContent | null
 }
 
 export interface IJsonSheet {


### PR DESCRIPTION
We can extend the `IContent` type with `null` for more flexibility

# Why?

APIs return the `null` value when they return nothing. In this case, the browser can receive a key-value pair with `null` value. Then, we can store this `null` value in a new Excel sheet (even if it's null); and then we won't receive a type error just because some key's value of some `content` is `null`

# How?

In this PR, I appended the `null` type under `IContent` type