### PR TITLE
fix: type `null` is not assignable to type `IContent`

### DIFF
--- a/packages/main-library/package.json
+++ b/packages/main-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-as-xlsx",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/main-library/src/__tests__/index.test.ts
+++ b/packages/main-library/src/__tests__/index.test.ts
@@ -182,5 +182,25 @@ describe("json-as-xlsx", () => {
       expect(booksSheet.A3.v).toBe("Git")
       expect(booksSheet.B3.v).toBe("Robert")
     })
+
+    it("should allow null value in content", () => {
+      const sheets = [
+        {
+          sheet: "Users",
+          columns: [{ label: "IP", value: "metadata.ip" }],
+          content: [
+            { name: "Martin", metadata: { ip: null } },
+            { name: "Robert", metadata: { ip: null } },
+          ],
+        },
+      ]
+      const buffer = jsonxlsx(sheets, settings)
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets.Users
+
+      expect(workSheet.A1.v).toBe("IP")
+      expect(workSheet.A2.v).toBe("")
+      expect(workSheet.A3.v).toBe("")
+    })
   })
 })

--- a/packages/main-library/src/index.ts
+++ b/packages/main-library/src/index.ts
@@ -2,7 +2,7 @@ import { utils, WorkBook, WorkSheet, write, writeFile, WritingOptions } from "xl
 
 export interface IColumn {
   label: string
-  value: string | ((value: IContent) => string | number | boolean | Date | IContent)
+  value: string | ((value: IContent) => string | number | boolean | Date | IContent | null)
   format?: string
 }
 
@@ -25,7 +25,7 @@ export interface ISettings {
 }
 
 export interface IJsonSheetRow {
-  [key: string]: string | number | boolean | Date | IContent
+  [key: string]: string | number | boolean | Date | IContent | null
 }
 
 export interface IWorksheetColumnWidth {
@@ -44,7 +44,7 @@ export const getContentProperty = (content: IContent, property: string): string 
       return value ?? ""
     }
 
-    if (value === undefined || typeof value === "string" || typeof value === "boolean" || typeof value === "number" || value instanceof Date) {
+    if (value === undefined || value === null || typeof value === "string" || typeof value === "boolean" || typeof value === "number" || value instanceof Date) {
       return ""
     }
 


### PR DESCRIPTION
# Description

1. I fixed `type 'null' is not assignable to type 'IContent'` error
2. I wrote a unit test in `packages/main-library/src/__tests__/index.test.ts` to test this change

# Test

## Test steps

1. Switch to this branch
3. Run `nvm use 16.14.2` to switch to Node version 16.14.2 (install it using `nvm` if it's not installed yet)
4. Run `yarn test` to run the test files
5. Run `yarn build` to build the package

## Expected results

- Test should pass without any errors
- The package builds without any errors

# Further comments

The GH actions tests are failing because [the tests are being run on the last commit](https://github.com/LuisEnMarroquin/json-as-xlsx/actions/runs/5910499342/job/16032164310?pr=83#step:2:160) (which is a [broken commit](https://github.com/LuisEnMarroquin/json-as-xlsx/commit/728ed7018dabe5688e83c21a842baaa3648f896f)).

To run it on the last commit, follow the steps:
1- reset “develop” branch to latest working commit (1dac19b)
2- sync your “develop” and “main” branch
3- merge this PR. It will be merged to the “develop” branch

Now, the tests should pass; because I ran GH actions on my bug reproduction environment

- My bug reproduction environment: https://github.com/cjxe/json-as-xlsx/pull/2