### PR TITLE
release: prepare json-as-xlsx 2.6.2 fixes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,21 @@ users' code keeps working when they upgrade:
   tracked modifications, deletions, and new files. Do not leave local changes
   uncommitted unless Luis explicitly asks to exclude something.
 
+## Agent-Specific Instructions
+
+### OpenAI / Codex
+
+- When OpenAI Codex creates a commit, include this trailer at the end of the
+  commit message:
+  `Co-authored-by: OpenAI Codex <noreply@openai.com>`
+
+### Anthropic / Claude
+
+- When Claude Code creates a commit, keep using its standard generated-by footer
+  and co-author trailer:
+  `🤖 Generated with [Claude Code](https://claude.ai/code)`
+  `Co-Authored-By: Claude <noreply@anthropic.com>`
+
 ## Pull request review comments — IMPORTANT
 
 Whenever GitHub Copilot (or any reviewer) leaves review comments on a PR, handle

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,9 @@ mentions, multiple lines), the only real gotcha is this: **`--body` takes its
 value literally — it does NOT read stdin and does NOT interpret `@file`/`@-`.**
 So `--body @-` posts the literal string `@-`. Pick one of the forms below.
 
+- When replying to a specific person in a GitHub issue or PR comment, tag them
+  by GitHub username (e.g. `@username`) so the reply is clearly directed to
+  them.
 - **Inline via command substitution is fine** (a multi-line heredoc works
   perfectly — we use it for PR bodies):
   `gh pr comment <num> --repo <owner/repo> --body "$(cat <<'EOF' … EOF)"`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,30 @@ Notes: resolving threads needs the GraphQL API (REST can't) — list the PR's
 `reviewThreads` to get each thread id, then call the `resolveReviewThread`
 mutation. After pushing the fixes, re-request Copilot's review so it runs again.
 
+## Posting GitHub comments — IMPORTANT
+
+When posting issue/PR comments whose body contains Markdown (code blocks,
+mentions, multiple lines), the only real gotcha is this: **`--body` takes its
+value literally — it does NOT read stdin and does NOT interpret `@file`/`@-`.**
+So `--body @-` posts the literal string `@-`. Pick one of the forms below.
+
+- **Inline via command substitution is fine** (a multi-line heredoc works
+  perfectly — we use it for PR bodies):
+  `gh pr comment <num> --repo <owner/repo> --body "$(cat <<'EOF' … EOF)"`
+- **From a file or stdin** with `--body-file`:
+  - Issue: `gh issue comment <num> --repo <owner/repo> --body-file <file>`
+  - PR: `gh pr comment <num> --repo <owner/repo> --body-file <file>`
+  - `--body-file -` reads from stdin (e.g. a heredoc).
+- To **edit** an existing comment, PATCH it via the API (the numeric
+  `comment_id` is the `issuecomment-<id>` suffix in the comment URL). To read the
+  body from a file use `-F body=@<file>`, but note `-F` coerces types — a file
+  whose entire content is `true`/`false`/`null`/a number becomes that type
+  instead of a string. The fully safe form is to pass the string directly:
+  `gh api -X PATCH repos/<owner/repo>/issues/comments/<comment_id> -f body="$(cat <file>)"`.
+- After posting, verify the rendered body (e.g.
+  `gh api repos/<owner/repo>/issues/comments/<id> --jq .body`) instead of
+  assuming it worked.
+
 ## Versioning — IMPORTANT
 
 The released version lives in `packages/main-library/package.json`. When asked to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ for the rules.
 
 ## Unreleased
 
+- Added opt-in `writeEmptyValuesAsBlankCells` support so empty, null and missing
+  values can be exported as true blank cells in Excel.
 - Documentation overhaul: revamped `README.md` (installation, settings table,
   Node.js/buffer usage, hyperlink format, TypeScript notes) and `CONTRIBUTING.md`.
 - Added `SECURITY.md`, `CODE_OF_CONDUCT.md`, issue/PR templates.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,6 +97,21 @@ users' code keeps working when they upgrade:
   tracked modifications, deletions, and new files. Do not leave local changes
   uncommitted unless Luis explicitly asks to exclude something.
 
+## Agent-Specific Instructions
+
+### OpenAI / Codex
+
+- When OpenAI Codex creates a commit, include this trailer at the end of the
+  commit message:
+  `Co-authored-by: OpenAI Codex <noreply@openai.com>`
+
+### Anthropic / Claude
+
+- When Claude Code creates a commit, keep using its standard generated-by footer
+  and co-author trailer:
+  `🤖 Generated with [Claude Code](https://claude.ai/code)`
+  `Co-Authored-By: Claude <noreply@anthropic.com>`
+
 ## Pull request review comments — IMPORTANT
 
 Whenever GitHub Copilot (or any reviewer) leaves review comments on a PR, handle

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,6 +120,9 @@ mentions, multiple lines), the only real gotcha is this: **`--body` takes its
 value literally — it does NOT read stdin and does NOT interpret `@file`/`@-`.**
 So `--body @-` posts the literal string `@-`. Pick one of the forms below.
 
+- When replying to a specific person in a GitHub issue or PR comment, tag them
+  by GitHub username (e.g. `@username`) so the reply is clearly directed to
+  them.
 - **Inline via command substitution is fine** (a multi-line heredoc works
   perfectly — we use it for PR bodies):
   `gh pr comment <num> --repo <owner/repo> --body "$(cat <<'EOF' … EOF)"`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,30 @@ Notes: resolving threads needs the GraphQL API (REST can't) — list the PR's
 `reviewThreads` to get each thread id, then call the `resolveReviewThread`
 mutation. After pushing the fixes, re-request Copilot's review so it runs again.
 
+## Posting GitHub comments — IMPORTANT
+
+When posting issue/PR comments whose body contains Markdown (code blocks,
+mentions, multiple lines), the only real gotcha is this: **`--body` takes its
+value literally — it does NOT read stdin and does NOT interpret `@file`/`@-`.**
+So `--body @-` posts the literal string `@-`. Pick one of the forms below.
+
+- **Inline via command substitution is fine** (a multi-line heredoc works
+  perfectly — we use it for PR bodies):
+  `gh pr comment <num> --repo <owner/repo> --body "$(cat <<'EOF' … EOF)"`
+- **From a file or stdin** with `--body-file`:
+  - Issue: `gh issue comment <num> --repo <owner/repo> --body-file <file>`
+  - PR: `gh pr comment <num> --repo <owner/repo> --body-file <file>`
+  - `--body-file -` reads from stdin (e.g. a heredoc).
+- To **edit** an existing comment, PATCH it via the API (the numeric
+  `comment_id` is the `issuecomment-<id>` suffix in the comment URL). To read the
+  body from a file use `-F body=@<file>`, but note `-F` coerces types — a file
+  whose entire content is `true`/`false`/`null`/a number becomes that type
+  instead of a string. The fully safe form is to pass the string directly:
+  `gh api -X PATCH repos/<owner/repo>/issues/comments/<comment_id> -f body="$(cat <file>)"`.
+- After posting, verify the rendered body (e.g.
+  `gh api repos/<owner/repo>/issues/comments/<id> --jq .body`) instead of
+  assuming it worked.
+
 ## Versioning — IMPORTANT
 
 The released version lives in `packages/main-library/package.json`. When asked to

--- a/README.md
+++ b/README.md
@@ -131,6 +131,11 @@ xlsx(data, {
 
 Values like `0` and `false` are still written normally.
 
+This option applies to both string-path columns (`value: "email"`) and function
+columns (`value: (row) => row.email ?? ""`). Formats, hyperlinks and cell styles
+are applied only to cells that still have a value; blank cells remain truly
+blank. Sheets or multi-table entries with no content still render their headers.
+
 ### Callback
 
 If you want to inspect or post-process the workbook, pass a `callback` as the

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ You can see a live demo on any of these sites (there are several, just in case):
 - 🧭 Read deeply nested values (`"more.phone"`) or compute them with a function.
 - 🎨 Per-column number, date, currency and hyperlink formatting.
 - 🖌️ Opt-in cell styling for fonts, fills, borders, alignment and number formats.
+- ⬜ Opt-in true blank cells for empty, null or missing values.
 - 📐 Automatic column widths (tunable with `extraLength`).
 - ↔️ Right-to-left (RTL) sheet support.
 - 🌐 Works in the browser (file download) and in Node.js (file or buffer output).
@@ -79,6 +80,7 @@ let settings = {
   writeMode: "writeFile", // The available parameters are 'writeFile' and 'write'. This setting is optional. Useful in such cases https://docs.sheetjs.com/docs/solutions/output#example-remote-file
   writeOptions: {}, // Style options from https://docs.sheetjs.com/docs/api/write-options
   RTL: true, // Display the columns from right-to-left (the default value is false)
+  writeEmptyValuesAsBlankCells: false, // Set to true so Excel treats empty, null and missing values as blank cells
 }
 
 xlsx(data, settings) // Will download the excel file
@@ -94,6 +96,40 @@ xlsx(data, settings) // Will download the excel file
 | `writeMode`    | `"writeFile"`/`"write"` | `"writeFile"` | `"writeFile"` downloads/writes the file; `"write"` returns the raw data (e.g. a Node buffer).  |
 | `writeOptions` | `object`              | `{}`            | Passed straight to SheetJS — see [write options](https://docs.sheetjs.com/docs/api/write-options). |
 | `RTL`          | `boolean`             | `false`         | Render every sheet right-to-left.                                                             |
+| `writeEmptyValuesAsBlankCells` | `boolean` | `false` | Omit empty-string, `null`, `undefined` and missing-path values so Excel treats them as blank cells. |
+
+### True blank cells
+
+For backward compatibility, empty values are written as empty strings by
+default. Excel can count those cells as text values even when they look blank.
+Set `writeEmptyValuesAsBlankCells: true` to omit empty-string, `null`,
+`undefined` and missing-path values from the worksheet XML:
+
+```js
+let data = [
+  {
+    sheet: "Sparse data",
+    columns: [
+      { label: "ID", value: "id" },
+      { label: "Email", value: (row) => row.contact?.email ?? "" },
+      { label: "Score", value: "score", format: "0.00" },
+    ],
+    content: [
+      { id: "ID-101", contact: { email: "ada@example.com" }, score: 98.5 },
+      { id: "ID-102", contact: { email: "" } },
+      { id: "ID-103", score: null },
+      { id: "ID-104" },
+    ],
+  },
+]
+
+xlsx(data, {
+  fileName: "BlankCellSpreadsheet",
+  writeEmptyValuesAsBlankCells: true,
+})
+```
+
+Values like `0` and `false` are still written normally.
 
 ### Callback
 

--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ pnpm add json-as-xlsx
 
 ```js
 import xlsx from "json-as-xlsx"
-// or require
-let xlsx = require("json-as-xlsx")
+// Alternative import styles:
+// import { xlsx } from "json-as-xlsx"
+// const xlsx = require("json-as-xlsx")
 
 let data = [
   {
@@ -329,10 +330,13 @@ top-level `columns`/`content`.
 ## TypeScript
 
 The package is written in TypeScript and ships its own type definitions. The
-public interfaces are exported for your convenience:
+public interfaces are exported for your convenience. The `xlsx` function is
+available as both the default export and a named export:
 
 ```ts
 import xlsx, { IJsonSheet, ISettings, IColumn, IContent, ICellStyle } from "json-as-xlsx"
+// or:
+// import { xlsx, IJsonSheet, ISettings, IColumn, IContent, ICellStyle } from "json-as-xlsx"
 
 const data: IJsonSheet[] = [
   /* ... */

--- a/packages/demo-express/package.json
+++ b/packages/demo-express/package.json
@@ -11,7 +11,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^26.0.1",
     "express": "^5.2.1",
-    "json-as-xlsx": "2.6.1",
+    "json-as-xlsx": "2.6.2",
     "nodemon": "^3.1.14",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"

--- a/packages/demo-express/src/server.ts
+++ b/packages/demo-express/src/server.ts
@@ -173,6 +173,27 @@ const multiTableData: IJsonSheet[] = [
   },
 ]
 
+// Empty strings, nulls and missing paths can be exported as true blank cells so
+// Excel does not count them as text values.
+// Kept in parity with the React demo (packages/demo-reactjs/src/App.tsx)
+const blankCellData: IJsonSheet[] = [
+  {
+    sheet: "Sparse data",
+    columns: [
+      { label: "ID", value: "id" },
+      { label: "Name", value: "name" },
+      { label: "Email", value: (row: any) => row?.contact?.email ?? "" },
+      { label: "Score", value: "score", format: "0.00" },
+    ],
+    content: [
+      { id: "ID-101", name: "Ada Lovelace", contact: { email: "ada@example.com" }, score: 98.5 },
+      { id: "ID-102", name: "Grace Hopper", contact: { email: "" } },
+      { id: "ID-103", name: "Katherine Johnson", score: null },
+      { id: "ID-104", contact: {} },
+    ],
+  },
+]
+
 const settings: ISettings = {
   writeOptions: {
     type: "buffer",
@@ -222,6 +243,18 @@ app.get("/multi-table", (_, res) => {
   res.writeHead(200, {
     "Content-Type": "application/octet-stream",
     "Content-disposition": "attachment; filename=MySheet-MultiTable.xlsx",
+  })
+  res.end(buffer)
+})
+
+app.get("/blank-cells", (_, res) => {
+  const buffer = xlsx(blankCellData, {
+    ...settings,
+    writeEmptyValuesAsBlankCells: true,
+  })
+  res.writeHead(200, {
+    "Content-Type": "application/octet-stream",
+    "Content-disposition": "attachment; filename=MySheet-BlankCells.xlsx",
   })
   res.end(buffer)
 })

--- a/packages/demo-reactjs/package.json
+++ b/packages/demo-reactjs/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "json-as-xlsx": "2.6.1",
+    "json-as-xlsx": "2.6.2",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/packages/demo-reactjs/src/App.tsx
+++ b/packages/demo-reactjs/src/App.tsx
@@ -167,6 +167,26 @@ const multiTableData: IJsonSheet[] = [
   },
 ]
 
+// Empty strings, nulls and missing paths can be exported as true blank cells so
+// Excel does not count them as text values.
+const blankCellData: IJsonSheet[] = [
+  {
+    sheet: "Sparse data",
+    columns: [
+      { label: "ID", value: "id" },
+      { label: "Name", value: "name" },
+      { label: "Email", value: (row: any) => row?.contact?.email ?? "" },
+      { label: "Score", value: "score", format: "0.00" },
+    ],
+    content: [
+      { id: "ID-101", name: "Ada Lovelace", contact: { email: "ada@example.com" }, score: 98.5 },
+      { id: "ID-102", name: "Grace Hopper", contact: { email: "" } },
+      { id: "ID-103", name: "Katherine Johnson", score: null },
+      { id: "ID-104", contact: {} },
+    ],
+  },
+]
+
 const snippet = `import xlsx from "json-as-xlsx"
 
 const data = [{
@@ -183,7 +203,7 @@ const data = [{
 
 xlsx(data, { fileName: "MySpreadsheet" })`
 
-const features = ["📑 Multi-sheet", "🧱 Multi-table sheets", "🎨 Cell formatting", "🟦 TypeScript", "🌐 Browser & Node"]
+const features = ["📑 Multi-sheet", "🧱 Multi-table sheets", "🎨 Cell formatting", "⬜ True blank cells", "🟦 TypeScript", "🌐 Browser & Node"]
 
 function DownloadIcon() {
   return (
@@ -224,6 +244,10 @@ function App() {
     xlsx(multiTableData, { fileName: "MultiTableSpreadsheet" })
   }
 
+  const downloadBlankCellFile = () => {
+    xlsx(blankCellData, { fileName: "BlankCellSpreadsheet", writeEmptyValuesAsBlankCells: true })
+  }
+
   return (
     <div className="page">
       <main className="card">
@@ -253,6 +277,10 @@ function App() {
           <button className="download secondary" onClick={downloadMultiTableFile}>
             <DownloadIcon />
             Download multi-table
+          </button>
+          <button className="download secondary" onClick={downloadBlankCellFile}>
+            <DownloadIcon />
+            Download blank cells
           </button>
         </div>
 

--- a/packages/demo-reactjs/src/empty-node-builtin.ts
+++ b/packages/demo-reactjs/src/empty-node-builtin.ts
@@ -1,0 +1,10 @@
+// Empty stand-in for Node.js built-in modules (`fs`, `stream`, …) that the
+// `@e965/xlsx` (SheetJS) dependency `require()`s for its Node code paths.
+//
+// In the browser those paths never run — file generation uses a Blob download
+// instead. Without this shim, Vite "externalizes" the built-ins and logs
+// "Module <x> has been externalized for browser compatibility" warnings in the
+// console (see https://github.com/LuisEnMarroquin/json-as-xlsx/issues/96).
+// Aliasing the built-ins to this empty object silences the noise while keeping
+// the browser download path working.
+export default {}

--- a/packages/demo-reactjs/vite.config.ts
+++ b/packages/demo-reactjs/vite.config.ts
@@ -1,9 +1,26 @@
 import { defineConfig } from "vite"
 import react from "@vitejs/plugin-react"
+import { fileURLToPath } from "node:url"
+
+// `@e965/xlsx` (SheetJS, used by json-as-xlsx) `require()`s the Node built-ins
+// `fs` and `stream` for its Node-only code paths. In the browser Vite
+// "externalizes" them and logs "Module <x> has been externalized for browser
+// compatibility" warnings (see issue #96). Those paths never run in the browser
+// — downloads use a Blob — so we alias the built-ins to an empty module to
+// silence the warnings without affecting behavior.
+const emptyBuiltin = fileURLToPath(
+  new URL("./src/empty-node-builtin.ts", import.meta.url)
+)
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      fs: emptyBuiltin,
+      stream: emptyBuiltin,
+    },
+  },
   optimizeDeps: {
     include: ["json-as-xlsx"],
   },

--- a/packages/main-library/package.json
+++ b/packages/main-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-as-xlsx",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/main-library/src/__tests__/contentProperty.test.ts
+++ b/packages/main-library/src/__tests__/contentProperty.test.ts
@@ -10,6 +10,8 @@ test("Should access first level property", () => {
   expect(getContentProperty(supportTicket, "user")).toBe("daniel31")
 
   expect(getContentProperty(supportTicket, "description")).toBe("")
+
+  expect(getContentProperty(supportTicket, "description", { writeEmptyValuesAsBlankCells: true })).toBeNull()
 })
 
 test("Should access second level property", () => {
@@ -27,6 +29,8 @@ test("Should access second level property", () => {
   expect(getContentProperty(employee, "email.personal")).toBe("sophie@email.com")
 
   expect(getContentProperty(employee, "email.business")).toBe("")
+
+  expect(getContentProperty(employee, "email.business", { writeEmptyValuesAsBlankCells: true })).toBeNull()
 })
 
 test("Should access third level property", () => {
@@ -50,4 +54,17 @@ test("Should access third level property", () => {
   expect(getContentProperty(purchase, "costumer.billingAddress.postalCode")).toBe(55555)
 
   expect(getContentProperty(purchase, "costumer.billingAddress.countryCode")).toBe("")
+
+  expect(getContentProperty(purchase, "costumer.billingAddress.countryCode", { writeEmptyValuesAsBlankCells: true })).toBeNull()
+})
+
+test("Should optionally return null for empty string values", () => {
+  const user = {
+    id: "user-1",
+    email: "",
+  }
+
+  expect(getContentProperty(user, "email")).toBe("")
+
+  expect(getContentProperty(user, "email", { writeEmptyValuesAsBlankCells: true })).toBeNull()
 })

--- a/packages/main-library/src/__tests__/getJsonSheetRow.test.ts
+++ b/packages/main-library/src/__tests__/getJsonSheetRow.test.ts
@@ -51,6 +51,8 @@ test("", () => {
 
   expect(getJsonSheetRow(track, [{ label: "URI", value: "uri" }])).toEqual({ URI: "" })
 
+  expect(getJsonSheetRow(track, [{ label: "URI", value: "uri" }], { writeEmptyValuesAsBlankCells: true })).toEqual({ URI: null })
+
   expect(getJsonSheetRow(track, [{ label: "Album", value: "album" }])).toEqual({
     Album: {
       id: "532o48sn3",
@@ -60,4 +62,33 @@ test("", () => {
       releaseDate: "2014-03-11",
     },
   })
+})
+
+test("Should optionally keep function-column empty strings as blank cells", () => {
+  const track = {
+    id: "4ase432i",
+    uri: "",
+  }
+
+  expect(
+    getJsonSheetRow(track, [
+      {
+        label: "URI",
+        value: (content: IContent) => content.uri,
+      },
+    ])
+  ).toEqual({ URI: "" })
+
+  expect(
+    getJsonSheetRow(
+      track,
+      [
+        {
+          label: "URI",
+          value: (content: IContent) => content.uri,
+        },
+      ],
+      { writeEmptyValuesAsBlankCells: true }
+    )
+  ).toEqual({ URI: null })
 })

--- a/packages/main-library/src/__tests__/index.test.ts
+++ b/packages/main-library/src/__tests__/index.test.ts
@@ -343,6 +343,99 @@ describe("json-as-xlsx", () => {
       expect(workSheet.A3.v).toBe("")
     })
 
+    it("should write empty values as empty-string cells by default", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Users",
+          columns: [
+            { label: "ID", value: "id" },
+            { label: "Score", value: "score", format: "0.00" },
+            { label: "Email", value: (row: IContent) => row.email ?? "" },
+            { label: "Nested", value: "metadata.code" },
+          ],
+          content: [
+            { id: "ID-1", score: 42, email: "ada@example.com", metadata: { code: "A" } },
+            { id: "ID-2", email: "" },
+            { id: "ID-3", score: null, metadata: {} },
+          ],
+        },
+      ]
+
+      const buffer = jsonxlsx(sheets, settings)
+      const sheetXml = strFromU8(unzipXlsxBuffer(buffer)["xl/worksheets/sheet1.xml"])
+
+      expect(sheetXml).toMatch(/<c r="B3"[^>]*><v><\/v><\/c>/)
+      expect(sheetXml).toContain('<c r="C3" t="str"><v></v></c>')
+      expect(sheetXml).toContain('<c r="D3" t="str"><v></v></c>')
+      expect(sheetXml).toMatch(/<c r="B4"[^>]*><v><\/v><\/c>/)
+      expect(sheetXml).toContain('<c r="C4" t="str"><v></v></c>')
+      expect(sheetXml).toContain('<c r="D4" t="str"><v></v></c>')
+    })
+
+    it("should optionally write empty values as true blank cells", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Users",
+          columns: [
+            { label: "ID", value: "id" },
+            { label: "Score", value: "score", format: "0.00" },
+            { label: "Email", value: (row: IContent) => row.email ?? "" },
+            { label: "Nested", value: "metadata.code" },
+          ],
+          content: [
+            { id: "ID-1", score: 42, email: "ada@example.com", metadata: { code: "A" } },
+            { id: "ID-2", email: "" },
+            { id: "ID-3", score: null, metadata: {} },
+          ],
+        },
+      ]
+
+      const buffer = jsonxlsx(sheets, { ...settings, writeEmptyValuesAsBlankCells: true })
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets.Users
+      const sheetXml = strFromU8(unzipXlsxBuffer(buffer)["xl/worksheets/sheet1.xml"])
+
+      expect(workSheet.A3.v).toBe("ID-2")
+      expect(workSheet.A4.v).toBe("ID-3")
+      expect(workSheet.B3).toBeUndefined()
+      expect(workSheet.C3).toBeUndefined()
+      expect(workSheet.D3).toBeUndefined()
+      expect(workSheet.B4).toBeUndefined()
+      expect(workSheet.C4).toBeUndefined()
+      expect(workSheet.D4).toBeUndefined()
+      expect(sheetXml).not.toMatch(/<c r="B3"/)
+      expect(sheetXml).not.toMatch(/<c r="C3"/)
+      expect(sheetXml).not.toMatch(/<c r="D3"/)
+      expect(sheetXml).not.toMatch(/<c r="B4"/)
+      expect(sheetXml).not.toMatch(/<c r="C4"/)
+      expect(sheetXml).not.toMatch(/<c r="D4"/)
+    })
+
+    it("should optionally render empty-content sheets with headers only", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Headers only",
+          columns: [
+            { label: "Name", value: "name" },
+            { label: "Age", value: "age" },
+          ],
+          content: [],
+        },
+      ]
+
+      const buffer = jsonxlsx(sheets, { ...settings, writeEmptyValuesAsBlankCells: true })
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets["Headers only"]
+      const sheetXml = strFromU8(unzipXlsxBuffer(buffer)["xl/worksheets/sheet1.xml"])
+
+      expect(workSheet["!ref"]).toBe("A1:B1")
+      expect(workSheet.A1.v).toBe("Name")
+      expect(workSheet.B1.v).toBe("Age")
+      expect(sheetXml).not.toContain('<row r="2"')
+      expect(sheetXml).not.toContain('<c r="A2"')
+      expect(sheetXml).not.toContain('<c r="B2"')
+    })
+
     it("should not write style objects unless styles are enabled", () => {
       const sheets: IJsonSheet[] = [
         {

--- a/packages/main-library/src/__tests__/index.test.ts
+++ b/packages/main-library/src/__tests__/index.test.ts
@@ -100,6 +100,34 @@ describe("json-as-xlsx", () => {
     expect(result).toBeUndefined()
   })
 
+  // Regression guard for issue #87 ("xlsx is not a function"). We overwrite the
+  // whole `module.exports` with the `xlsx` function so `require("json-as-xlsx")`
+  // returns it directly. That override drops the named bindings tsc emitted, so
+  // they are re-attached. Without `xlsx`/`default` re-attached,
+  // `import { xlsx } from ...` and a default import transpiled to `.default`
+  // (TS without esModuleInterop) both resolve to undefined and crash.
+  describe("CommonJS export surface (issue #87)", () => {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const required = require("../index")
+
+    it("returns the xlsx function as the module itself", () => {
+      expect(typeof required).toBe("function")
+    })
+
+    it("re-attaches xlsx and default so named/default imports resolve to the function", () => {
+      expect(required.xlsx).toBe(required)
+      expect(required.default).toBe(required)
+    })
+
+    it("keeps the other named bindings after the module.exports override", () => {
+      expect(typeof required.utils).toBe("object")
+      expect(typeof required.getContentProperty).toBe("function")
+      expect(typeof required.getJsonSheetRow).toBe("function")
+      expect(typeof required.getWorksheetColumnWidths).toBe("function")
+      expect(required.libraryName).toBe("json-as-xlsx")
+    })
+  })
+
   describe("writeOptions.type is set to buffer", () => {
     const settings: ISettings = {
       writeOptions: {

--- a/packages/main-library/src/__tests__/index.test.ts
+++ b/packages/main-library/src/__tests__/index.test.ts
@@ -436,6 +436,37 @@ describe("json-as-xlsx", () => {
       expect(sheetXml).not.toContain('<c r="B2"')
     })
 
+    it("should keep styled empty values as true blank cells when enabled", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Styled blanks",
+          columns: [
+            { label: "Website", value: "url", format: "hyperlink", cellStyle: { font: { bold: true } } },
+            { label: "Amount", value: "amount", format: "0.00", cellStyle: { font: { italic: true } } },
+            { label: "Name", value: "name", cellStyle: { fill: { fgColor: { rgb: "DCFCE7" } } } },
+          ],
+          content: [
+            { url: "", amount: null, name: "Ada" },
+            { url: "https://example.com", amount: 42, name: "" },
+          ],
+        },
+      ]
+
+      const buffer = jsonxlsx(sheets, {
+        ...settings,
+        enableStyles: true,
+        writeEmptyValuesAsBlankCells: true,
+      })
+      const sheetXml = strFromU8(unzipXlsxBuffer(buffer)["xl/worksheets/sheet1.xml"])
+
+      expect(sheetXml).not.toMatch(/<c r="A2"/)
+      expect(sheetXml).not.toMatch(/<c r="B2"/)
+      expect(sheetXml).not.toMatch(/<c r="C3"/)
+      expect(sheetXml).toMatch(/<c r="C2"[^>]* s="\d+"[^>]*>/)
+      expect(sheetXml).toMatch(/<c r="A3"[^>]* s="\d+"[^>]*>/)
+      expect(sheetXml).toMatch(/<c r="B3"[^>]* s="\d+"[^>]*>/)
+    })
+
     it("should not write style objects unless styles are enabled", () => {
       const sheets: IJsonSheet[] = [
         {
@@ -988,6 +1019,38 @@ describe("json-as-xlsx", () => {
 
       expect(workSheet.A1.v).toBe("Name")
       expect(workSheet.A2.v).toBe("Alice")
+    })
+
+    it("renders empty tables with headers only when blank cells are enabled", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Multi",
+          tables: [
+            {
+              columns: [{ label: "Name", value: "name" }],
+              content: [{ name: "Alice" }],
+            },
+            {
+              columns: [
+                { label: "Product", value: "product" },
+                { label: "Price", value: "price" },
+              ],
+              content: [],
+            },
+          ],
+        },
+      ]
+
+      const workBook = readBufferWorkBook(jsonxlsx(sheets, { ...bufferSettings, writeEmptyValuesAsBlankCells: true }))
+      const workSheet = workBook.Sheets.Multi
+
+      expect(workSheet.A1.v).toBe("Name")
+      expect(workSheet.A2.v).toBe("Alice")
+      expect(workSheet.A3).toBeUndefined()
+      expect(workSheet.A4.v).toBe("Product")
+      expect(workSheet.B4.v).toBe("Price")
+      expect(workSheet.A5).toBeUndefined()
+      expect(workSheet.B5).toBeUndefined()
     })
   })
 

--- a/packages/main-library/src/__tests__/index.test.ts
+++ b/packages/main-library/src/__tests__/index.test.ts
@@ -467,6 +467,42 @@ describe("json-as-xlsx", () => {
       expect(sheetXml).toMatch(/<c r="B3"[^>]* s="\d+"[^>]*>/)
     })
 
+    it("should omit direct styled empty cell objects when blank cells are enabled", () => {
+      const sheets: IJsonSheet[] = [
+        {
+          sheet: "Direct styled blanks",
+          columns: [
+            { label: "Styled empty", value: "styledEmpty" },
+            { label: "Typed empty", value: "typedEmpty" },
+            { label: "Styled filled", value: "styledFilled" },
+          ],
+          content: [
+            {
+              styledEmpty: { v: "", t: "s", s: { font: { bold: true } } },
+              typedEmpty: { v: "", t: "s" },
+              styledFilled: { v: "Ada", t: "s", s: { font: { italic: true } } },
+            },
+          ],
+        },
+      ]
+
+      const buffer = jsonxlsx(sheets, {
+        ...settings,
+        enableStyles: true,
+        writeEmptyValuesAsBlankCells: true,
+      })
+      const workBook = readBufferWorkBook(buffer)
+      const workSheet = workBook.Sheets["Direct styled blanks"]
+      const sheetXml = strFromU8(unzipXlsxBuffer(buffer)["xl/worksheets/sheet1.xml"])
+
+      expect(workSheet.A2).toBeUndefined()
+      expect(workSheet.B2).toBeUndefined()
+      expect(workSheet.C2.v).toBe("Ada")
+      expect(sheetXml).not.toMatch(/<c r="A2"/)
+      expect(sheetXml).not.toMatch(/<c r="B2"/)
+      expect(sheetXml).toMatch(/<c r="C2"[^>]* s="\d+"[^>]*>/)
+    })
+
     it("should not write style objects unless styles are enabled", () => {
       const sheets: IJsonSheet[] = [
         {

--- a/packages/main-library/src/index.ts
+++ b/packages/main-library/src/index.ts
@@ -420,7 +420,17 @@ export default xlsx
 
 export const libraryName = "json-as-xlsx"
 
+// `module.exports = xlsx` makes `require("json-as-xlsx")` (and a bare
+// `import xlsx from ...`) return the function directly. Reassigning the whole
+// exports object would otherwise drop the named bindings tsc emitted, so we
+// re-attach them here. `xlsx` and `default` are re-attached too: without them
+// `import { xlsx } from ...` resolves to `undefined`, and a default import
+// transpiled to `.default` (e.g. TS without esModuleInterop) crashes with
+// "xlsx is not a function". See issue #87.
 module.exports = xlsx
+module.exports.xlsx = xlsx
+module.exports.default = xlsx
+module.exports.libraryName = libraryName
 module.exports.getContentProperty = getContentProperty
 module.exports.getJsonSheetRow = getJsonSheetRow
 module.exports.getWorksheetColumnWidths = getWorksheetColumnWidths

--- a/packages/main-library/src/index.ts
+++ b/packages/main-library/src/index.ts
@@ -47,6 +47,13 @@ export interface ISettings {
   writeOptions?: WritingOptions
   writeMode?: string
   RTL?: boolean
+  // Opt-in: write null, undefined and empty-string values as true blank cells
+  // instead of empty-string cells. Defaults to false for backward compatibility.
+  writeEmptyValuesAsBlankCells?: boolean
+}
+
+export interface IEmptyCellOptions {
+  writeEmptyValuesAsBlankCells?: boolean
 }
 
 export interface IJsonSheetRow {
@@ -61,16 +68,27 @@ export type IWorkbookCallback = (workbook: WorkBook) => void
 
 export { utils, WorkBook, WorkSheet }
 
-export const getContentProperty = (content: IContent, property: string): string | number | boolean | Date | IContent | IStyledCell => {
-  const accessContentProperties = (content: IContent, properties: string[]): string | number | boolean | Date | IContent | IStyledCell => {
+const normalizeEmptyCellValue = (value: IContentValue | undefined, options: IEmptyCellOptions = {}): IContentValue => {
+  if (options.writeEmptyValuesAsBlankCells && (value === undefined || value === null || value === "")) {
+    return null
+  }
+
+  return value ?? ""
+}
+
+export function getContentProperty(content: IContent, property: string): Exclude<IContentValue, null>
+export function getContentProperty(content: IContent, property: string, options: IEmptyCellOptions & { writeEmptyValuesAsBlankCells: true }): IContentValue
+export function getContentProperty(content: IContent, property: string, options: IEmptyCellOptions): IContentValue
+export function getContentProperty(content: IContent, property: string, options: IEmptyCellOptions = {}): IContentValue {
+  const accessContentProperties = (content: IContent, properties: string[]): IContentValue => {
     const value = content[properties[0]]
 
     if (properties.length === 1) {
-      return value ?? ""
+      return normalizeEmptyCellValue(value, options)
     }
 
     if (value === undefined || value === null || typeof value === "string" || typeof value === "boolean" || typeof value === "number" || value instanceof Date) {
-      return ""
+      return normalizeEmptyCellValue(undefined, options)
     }
 
     return accessContentProperties(value as IContent, properties.slice(1))
@@ -80,13 +98,13 @@ export const getContentProperty = (content: IContent, property: string): string 
   return accessContentProperties(content, properties)
 }
 
-export const getJsonSheetRow = (content: IContent, columns: IColumn[]): IJsonSheetRow => {
+export const getJsonSheetRow = (content: IContent, columns: IColumn[], options: IEmptyCellOptions = {}): IJsonSheetRow => {
   const jsonSheetRow: IJsonSheetRow = {}
   columns.forEach((column) => {
     if (typeof column.value === "function") {
-      jsonSheetRow[column.label] = column.value(content)
+      jsonSheetRow[column.label] = normalizeEmptyCellValue(column.value(content), options)
     } else {
-      jsonSheetRow[column.label] = getContentProperty(content, column.value)
+      jsonSheetRow[column.label] = getContentProperty(content, column.value, options)
     }
   })
   return jsonSheetRow
@@ -117,7 +135,7 @@ const applyColumnFormat = (worksheet: WorkSheet, table: IPlacedTable, columnForm
     for (let row = table.startRow + 1; row <= table.startRow + table.dataRowCount; ++row) {
       const ref = utils.encode_cell({ r: row, c: column })
 
-      if (worksheet[ref]) {
+      if (worksheet[ref] && !isBlankWorksheetCell(worksheet[ref])) {
         switch (columnFormat) {
           case "hyperlink":
             worksheet[ref].l = { Target: worksheet[ref].v }
@@ -164,7 +182,7 @@ const applyColumnStyles = (worksheet: WorkSheet, table: IPlacedTable, columnStyl
     for (let row = table.startRow + 1; row <= table.startRow + table.dataRowCount; ++row) {
       const ref = utils.encode_cell({ r: row, c: column })
 
-      if (worksheet[ref]) {
+      if (worksheet[ref] && !isBlankWorksheetCell(worksheet[ref])) {
         applyCellStyles(worksheet[ref] as IStyledCell, columnStyle)
       }
     }
@@ -203,6 +221,10 @@ const getObjectLength = (object: unknown): number => {
   return 0
 }
 
+const isBlankWorksheetCell = (cell: WorkSheet[string]): boolean => {
+  return cell.t === "z" || cell.v === null || cell.v === undefined
+}
+
 export const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: number = 1): IWorksheetColumnWidth[] => {
   const columnLetters: string[] = getWorksheetColumnIds(worksheet)
 
@@ -232,9 +254,13 @@ export const getWorksheetColumnWidths = (worksheet: WorkSheet, extraLength: numb
   })
 }
 
-const buildJsonSheetRows = (columns: IColumn[], content: IContent[]): IJsonSheetRow[] => {
+const buildJsonSheetRows = (columns: IColumn[], content: IContent[], settings: ISettings): IJsonSheetRow[] => {
   if (content.length > 0) {
-    return content.map((contentItem) => getJsonSheetRow(contentItem, columns))
+    return content.map((contentItem) => getJsonSheetRow(contentItem, columns, settings))
+  }
+
+  if (settings.writeEmptyValuesAsBlankCells) {
+    return []
   }
 
   // If there's no content, show only column labels
@@ -256,15 +282,16 @@ const getWorksheet = (jsonSheet: IJsonSheet, settings: ISettings): WorkSheet => 
   const placedTables: IPlacedTable[] = []
 
   tables.forEach((table) => {
-    const jsonSheetRows = buildJsonSheetRows(table.columns, table.content)
+    const jsonSheetRows = buildJsonSheetRows(table.columns, table.content, settings)
+    const jsonSheetOptions = table.content.length === 0 && settings.writeEmptyValuesAsBlankCells ? { header: table.columns.map((column) => column.label) } : {}
     const startRow = nextRow
     const startCol = nextCol
 
     if (!worksheet) {
       // First table anchors the worksheet at A1 (both layouts start at 0,0).
-      worksheet = utils.json_to_sheet(jsonSheetRows)
+      worksheet = utils.json_to_sheet(jsonSheetRows, jsonSheetOptions)
     } else {
-      utils.sheet_add_json(worksheet, jsonSheetRows, { origin: { r: startRow, c: startCol } })
+      utils.sheet_add_json(worksheet, jsonSheetRows, { ...jsonSheetOptions, origin: { r: startRow, c: startCol } })
     }
 
     placedTables.push({ columns: table.columns, startRow, startCol, dataRowCount: jsonSheetRows.length })

--- a/packages/main-library/src/index.ts
+++ b/packages/main-library/src/index.ts
@@ -73,6 +73,14 @@ const normalizeEmptyCellValue = (value: IContentValue | undefined, options: IEmp
     return null
   }
 
+  if (options.writeEmptyValuesAsBlankCells && isStyledCell(value)) {
+    const styledValue = (value as IStyledCell & { v?: unknown }).v
+
+    if (styledValue === undefined || styledValue === null || styledValue === "") {
+      return null
+    }
+  }
+
   return value ?? ""
 }
 


### PR DESCRIPTION
## Summary

Prepares `json-as-xlsx@2.6.2` by bundling the current `develop` fixes and documentation updates for the next `develop -> main` merge.

This PR now covers:

- Fixes #96 by silencing Vite browser externalization warnings in the React demo.
- Fixes #87 by restoring runtime `xlsx` and `default` bindings after the CommonJS `module.exports = xlsx` assignment.
- Fixes #76 by adding opt-in true blank-cell output for empty strings, `null`, `undefined`, and missing paths.
- Tightens blank-cell behavior for direct styled/typed cell objects so styled empty values are also omitted when blank-cell mode is enabled.
- Updates the React and Express demos so the new blank-cell example is shown in both demo surfaces.
- Bumps the demo workspace dependencies and main package version to `2.6.2`.
- Expands README/CHANGELOG docs for settings, import usage, blank-cell behavior, and the new named `xlsx` import.
- Keeps `AGENTS.md` and `CLAUDE.md` synchronized with GitHub comment posting workflow notes and agent-specific commit footer instructions.

## Commits Included

- `1c65714` — Document GitHub comment posting in `CLAUDE.md` / `AGENTS.md`.
- `0b47623` — Silence Node built-in externalization warnings in the React + Vite demo.
- `249eba9` — Bump `json-as-xlsx` to `2.6.2` across the main package and demos.
- `9fc97ea` — Expose `xlsx` through CommonJS interop for named/default imports.
- `9a39f92` — Add opt-in `writeEmptyValuesAsBlankCells` support.
- `5e70a2b` — Add regression coverage for blank-cell edge cases.
- `f3d5268` — Clarify blank-cell behavior in docs.
- `32008eb` — Document the named `xlsx` import.
- `62dc141` — Omit styled empty cell objects from blank-cell output and document agent-specific commit trailers.

## Details

### Vite demo warning fix (#96)

`@e965/xlsx` references Node-only built-ins (`fs`, `stream`) from its CommonJS build. Those paths are not used in the browser demo, but Vite still externalized them and logged browser-compatibility warnings. The React demo now aliases those built-ins to a tiny empty module so the browser console stays clean while downloads continue to work.

### Import interop fix (#87)

The package intentionally keeps `require("json-as-xlsx")` returning the `xlsx` function directly. Reassigning `module.exports` dropped the runtime named/default bindings that TS/ESM import styles expect. The export surface now re-attaches `xlsx`, `default`, `libraryName`, helpers, and `utils` so these all resolve correctly:

```ts
import xlsx from "json-as-xlsx"
import { xlsx } from "json-as-xlsx"
import * as jsonAsXlsx from "json-as-xlsx"
const xlsx = require("json-as-xlsx")
```

### True blank cells (#76)

A new opt-in setting, `writeEmptyValuesAsBlankCells`, omits empty values from the worksheet XML instead of writing empty-string cells. This preserves the old default behavior for backward compatibility, while allowing Excel to treat those cells as truly blank when users enable the option.

The implementation covers string-path columns, function columns, direct styled/typed cell objects, missing nested paths, `null`, `undefined`, empty strings, headers-only sheets, styles, formats, and multi-table behavior.

### Docs and demo parity

The README now documents the new setting, import styles, settings table, Node/buffer usage, and release notes. The React and Express demos both include equivalent blank-cell examples, keeping the demo surfaces in sync.

`AGENTS.md` and `CLAUDE.md` also now include agent-specific commit footer guidance for OpenAI Codex and Anthropic Claude while staying byte-for-byte synchronized.

## Verification

Ran locally with Node `24.11.1` from `.nvmrc`:

- `yarn test` — 4 suites passed, 55 tests passed.
- `yarn build` — main library and React demo build passed.
- Manual `require`, default import, named import, and namespace import checks against the built/package entry all resolved `xlsx` as a function.
- Manual #76 reproduction with 1000 sparse rows confirmed blank-cell mode removes the empty cell XML entries (`5005` cell tags by default vs `1005` with `writeEmptyValuesAsBlankCells: true`).
- Regression coverage now verifies direct styled/typed empty cell objects are omitted while non-empty styled cells keep their style.
- `cmp -s AGENTS.md CLAUDE.md` confirmed both assistant instruction files still match exactly.

🤖 Generated with Codex