### PR TITLE
[codex] Prepare 2.6.3 release, demos, and CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version-file: .nvmrc
       - run: yarn
@@ -39,7 +39,7 @@ jobs:
           gh release create ${{ env.CURRENT_VERSION }} -F README.md -t "Released ${{ env.CURRENT_VERSION }}"
       - name: Prepare static files for deployment
         run: yarn run static
-      - uses: JamesIves/github-pages-deploy-action@v4
+      - uses: JamesIves/github-pages-deploy-action@v4.8.0
         with:
           folder: build
           branch: gh-pages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
       id-token: write
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
-      - uses: actions/setup-node@v6
+      - uses: actions/checkout@v7.0.0
+      - uses: actions/setup-node@v6.4.0
         with:
           node-version-file: .nvmrc
       - run: yarn

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: actions/setup-node@v6
         with:
           node-version-file: .nvmrc

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,6 +9,16 @@ Guidance for AI coding assistants (e.g. Claude Code) when working in this reposi
 - After editing them, verify from the repository root with `cmp -s AGENTS.md CLAUDE.md`.
 - Do not leave instructions, notes, preferences, or knowledge updates only in one of the two files.
 
+## Concurrent AI Work — IMPORTANT
+
+- Multiple AI assistants may work in this repository at the same time.
+- If you notice changes you did not make, do **not** edit, revert, stage, or
+  otherwise disturb them unless Luis explicitly asks you to handle those exact
+  changes. They likely belong to another AI assistant working in parallel.
+- If those parallel changes affect your task, inspect them enough to avoid
+  conflicts and work around them. Ask Luis before proceeding only if they make
+  your task impossible or unsafe.
+
 ## Project
 
 `json-as-xlsx` — a Yarn + Lerna monorepo. Packages live in `packages/*`:
@@ -181,6 +191,15 @@ digit (0–9) and rolls over instead of going to 10**:
   e.g. `1.0.9` → `1.1.0` (never `1.0.10`).
 - **When both the minor and the patch are `.9`, bump the major and reset both to 0.**
   e.g. `1.9.9` → `2.0.0` (never `1.9.10` or `1.10.0`).
+- When bumping the package version, update every place that intentionally pins
+  the library version:
+  - `packages/main-library/package.json` → `version` (the released npm version).
+  - `packages/demo-reactjs/package.json` → `dependencies["json-as-xlsx"]`.
+  - `packages/demo-express/package.json` → `dependencies["json-as-xlsx"]`.
+- After the bump, inspect the diff and search the repo for the previous version
+  and the new version. Do not leave dangling old-version references, mismatched
+  demo dependency pins, stale generated metadata, or any other version-related
+  loose ends just because the main package version changed.
 
 ## Deploys — who deploys what
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,11 @@ users' code keeps working when they upgrade:
 - When the AI makes a commit, it must include **all pending worktree changes**:
   tracked modifications, deletions, and new files. Do not leave local changes
   uncommitted unless Luis explicitly asks to exclude something.
+- When Luis writes `/gacp` or `gacp`, treat it as a request to run the full git
+  add, commit, and push flow for the current task. The AI tool has permission to
+  stage all pending changes, create an appropriate commit, and push `develop`
+  without asking for extra confirmation, while still following the branch and
+  commit rules above.
 
 ## Agent-Specific Instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,16 @@ Use the Node version in `.nvmrc` (currently `24.11.1`). Cloudflare reads `.nvmrc
 so it must stay on a version supported by the toolchain (lerna 9 needs
 `^20.19 || ^22.12 || >=24`).
 
+## Repository language — IMPORTANT
+
+- English is the language of this repository.
+- All repository artifacts must be written in English, including code,
+  comments, documentation, commit messages, pull request titles/descriptions,
+  issue comments, pull request review replies, release notes, examples, and
+  user-facing copy in the demos.
+- Do not add Spanish text to repository files or GitHub comments unless Luis
+  explicitly asks for Spanish text for a specific user-facing purpose.
+
 ## Demo parity — IMPORTANT
 
 `demo-reactjs` (the web UI) and `demo-express` (the API) are two views of the
@@ -158,7 +168,7 @@ So `--body @-` posts the literal string `@-`. Pick one of the forms below.
 ## Versioning — IMPORTANT
 
 The released version lives in `packages/main-library/package.json`. When asked to
-"bump the version" (subir versión), follow these rules — **each segment is a single
+"bump the version", follow these rules — **each segment is a single
 digit (0–9) and rolls over instead of going to 10**:
 
 - **Default: bump the patch.** e.g. `2.5.7` → `2.5.8`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ for the rules.
 
 ## Unreleased
 
+- Minify all JavaScript files published in the npm package.
 - Added opt-in `writeEmptyValuesAsBlankCells` support so empty, null and missing
   values can be exported as true blank cells in Excel.
 - Documentation overhaul: revamped `README.md` (installation, settings table,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,16 @@ Guidance for AI coding assistants (e.g. Claude Code) when working in this reposi
 - After editing them, verify from the repository root with `cmp -s AGENTS.md CLAUDE.md`.
 - Do not leave instructions, notes, preferences, or knowledge updates only in one of the two files.
 
+## Concurrent AI Work — IMPORTANT
+
+- Multiple AI assistants may work in this repository at the same time.
+- If you notice changes you did not make, do **not** edit, revert, stage, or
+  otherwise disturb them unless Luis explicitly asks you to handle those exact
+  changes. They likely belong to another AI assistant working in parallel.
+- If those parallel changes affect your task, inspect them enough to avoid
+  conflicts and work around them. Ask Luis before proceeding only if they make
+  your task impossible or unsafe.
+
 ## Project
 
 `json-as-xlsx` — a Yarn + Lerna monorepo. Packages live in `packages/*`:
@@ -181,6 +191,15 @@ digit (0–9) and rolls over instead of going to 10**:
   e.g. `1.0.9` → `1.1.0` (never `1.0.10`).
 - **When both the minor and the patch are `.9`, bump the major and reset both to 0.**
   e.g. `1.9.9` → `2.0.0` (never `1.9.10` or `1.10.0`).
+- When bumping the package version, update every place that intentionally pins
+  the library version:
+  - `packages/main-library/package.json` → `version` (the released npm version).
+  - `packages/demo-reactjs/package.json` → `dependencies["json-as-xlsx"]`.
+  - `packages/demo-express/package.json` → `dependencies["json-as-xlsx"]`.
+- After the bump, inspect the diff and search the repo for the previous version
+  and the new version. Do not leave dangling old-version references, mismatched
+  demo dependency pins, stale generated metadata, or any other version-related
+  loose ends just because the main package version changed.
 
 ## Deploys — who deploys what
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,6 +106,11 @@ users' code keeps working when they upgrade:
 - When the AI makes a commit, it must include **all pending worktree changes**:
   tracked modifications, deletions, and new files. Do not leave local changes
   uncommitted unless Luis explicitly asks to exclude something.
+- When Luis writes `/gacp` or `gacp`, treat it as a request to run the full git
+  add, commit, and push flow for the current task. The AI tool has permission to
+  stage all pending changes, create an appropriate commit, and push `develop`
+  without asking for extra confirmation, while still following the branch and
+  commit rules above.
 
 ## Agent-Specific Instructions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,16 @@ Use the Node version in `.nvmrc` (currently `24.11.1`). Cloudflare reads `.nvmrc
 so it must stay on a version supported by the toolchain (lerna 9 needs
 `^20.19 || ^22.12 || >=24`).
 
+## Repository language — IMPORTANT
+
+- English is the language of this repository.
+- All repository artifacts must be written in English, including code,
+  comments, documentation, commit messages, pull request titles/descriptions,
+  issue comments, pull request review replies, release notes, examples, and
+  user-facing copy in the demos.
+- Do not add Spanish text to repository files or GitHub comments unless Luis
+  explicitly asks for Spanish text for a specific user-facing purpose.
+
 ## Demo parity — IMPORTANT
 
 `demo-reactjs` (the web UI) and `demo-express` (the API) are two views of the
@@ -158,7 +168,7 @@ So `--body @-` posts the literal string `@-`. Pick one of the forms below.
 ## Versioning — IMPORTANT
 
 The released version lives in `packages/main-library/package.json`. When asked to
-"bump the version" (subir versión), follow these rules — **each segment is a single
+"bump the version", follow these rules — **each segment is a single
 digit (0–9) and rolls over instead of going to 10**:
 
 - **Default: bump the patch.** e.g. `2.5.7` → `2.5.8`.

--- a/package.json
+++ b/package.json
@@ -15,9 +15,9 @@
     "lerna": "^9.0.7"
   },
   "comments": {
-    "resolutions": "babel-plugin-istanbul@7.0.1 (pulled by jest's coverage) ships a stray 'workspaces' field, which makes yarn print 'Workspaces can only be enabled in private projects.' on every install. 7.0.0 is identical (same deps/main) but lacks that field, so we pin it here."
+    "resolutions": "Jest coverage still requests babel-plugin-istanbul ^7.0.1. Keep this resolution until Jest's dependency range accepts v8, so Yarn can install the current version and `yarn outdated` stays clean."
   },
   "resolutions": {
-    "babel-plugin-istanbul": "7.0.0"
+    "babel-plugin-istanbul": "8.0.0"
   }
 }

--- a/packages/demo-express/package.json
+++ b/packages/demo-express/package.json
@@ -11,7 +11,7 @@
     "@types/express": "^5.0.6",
     "@types/node": "^26.0.1",
     "express": "^5.2.1",
-    "json-as-xlsx": "2.6.2",
+    "json-as-xlsx": "2.6.3",
     "nodemon": "^3.1.14",
     "ts-node": "^10.9.2",
     "typescript": "^6.0.3"

--- a/packages/demo-express/src/index.html
+++ b/packages/demo-express/src/index.html
@@ -14,10 +14,16 @@
       <a href="/rtl">Download rtl example</a>
     </p>
     <p>
+      <a href="/links">Download links example</a>
+    </p>
+    <p>
       <a href="/styled">Download styled example</a>
     </p>
     <p>
       <a href="/multi-table">Download multi-table example</a>
+    </p>
+    <p>
+      <a href="/blank-cells">Download blank cells example</a>
     </p>
   </body>
 </html>

--- a/packages/demo-express/src/server.ts
+++ b/packages/demo-express/src/server.ts
@@ -194,6 +194,24 @@ const blankCellData: IJsonSheet[] = [
   },
 ]
 
+// Hyperlink columns turn URL strings into clickable links in Excel.
+// Kept in parity with the React demo (packages/demo-reactjs/src/App.tsx)
+const linkData: IJsonSheet[] = [
+  {
+    sheet: "Project links",
+    columns: [
+      { label: "Resource", value: "resource" },
+      { label: "URL", value: "url", format: "hyperlink" },
+      { label: "Owner", value: "owner" },
+    ],
+    content: [
+      { resource: "GitHub repository", url: "https://github.com/LuisEnMarroquin/json-as-xlsx", owner: "Open source" },
+      { resource: "npm package", url: "https://www.npmjs.com/package/json-as-xlsx", owner: "Registry" },
+      { resource: "Live demo", url: "https://xlsx.luismarroquin.com", owner: "Cloudflare Pages" },
+    ],
+  },
+]
+
 const settings: ISettings = {
   writeOptions: {
     type: "buffer",
@@ -222,6 +240,15 @@ app.get("/rtl", (_, res) => {
   res.writeHead(200, {
     "Content-Type": "application/octet-stream",
     "Content-disposition": "attachment; filename=MySheet-RTL.xlsx",
+  })
+  res.end(buffer)
+})
+
+app.get("/links", (_, res) => {
+  const buffer = xlsx(linkData, settings)
+  res.writeHead(200, {
+    "Content-Type": "application/octet-stream",
+    "Content-disposition": "attachment; filename=MySheet-Links.xlsx",
   })
   res.end(buffer)
 })

--- a/packages/demo-reactjs/package.json
+++ b/packages/demo-reactjs/package.json
@@ -10,7 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "json-as-xlsx": "2.6.2",
+    "json-as-xlsx": "2.6.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7"
   },

--- a/packages/demo-reactjs/src/App.css
+++ b/packages/demo-reactjs/src/App.css
@@ -85,8 +85,20 @@
   border-radius: 10px;
 }
 
-.actions {
+.downloads {
   margin-top: 2rem;
+}
+
+.downloads h2 {
+  margin: 0;
+  color: #dbe7f3;
+  font-size: 0.9rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.actions {
+  margin-top: 0.85rem;
   display: flex;
   flex-wrap: wrap;
   justify-content: center;
@@ -100,31 +112,52 @@
   font-family: inherit;
   font-size: 1.02rem;
   font-weight: 600;
-  color: #04130b;
-  background: linear-gradient(135deg, #6ee7b7, #21a366);
+  color: var(--download-color);
+  background: var(--download-bg);
   border: 0;
   padding: 0.85rem 1.6rem;
   border-radius: 12px;
   cursor: pointer;
-  box-shadow: 0 14px 32px -10px rgba(33, 163, 102, 0.6);
+  box-shadow: 0 14px 32px -10px var(--download-shadow);
   transition: transform 0.15s ease, box-shadow 0.15s ease, filter 0.15s ease;
 }
 
-.download.secondary {
-  color: #f0f9ff;
-  background: linear-gradient(135deg, #38bdf8, #1d4ed8);
-  border: 0;
-  box-shadow: 0 14px 32px -10px rgba(37, 99, 235, 0.6);
+.download.example {
+  --download-color: #04130b;
+  --download-bg: linear-gradient(135deg, #6ee7b7, #21a366);
+  --download-shadow: rgba(33, 163, 102, 0.6);
+  --download-hover-shadow: rgba(33, 163, 102, 0.72);
+  --download-focus: #6ee7b7;
+}
+
+.download.styled {
+  --download-color: #f0f9ff;
+  --download-bg: linear-gradient(135deg, #38bdf8, #2563eb);
+  --download-shadow: rgba(37, 99, 235, 0.6);
+  --download-hover-shadow: rgba(37, 99, 235, 0.75);
+  --download-focus: #7dd3fc;
+}
+
+.download.multiTable {
+  --download-color: #fff7ed;
+  --download-bg: linear-gradient(135deg, #f97316, #c2410c);
+  --download-shadow: rgba(234, 88, 12, 0.6);
+  --download-hover-shadow: rgba(234, 88, 12, 0.75);
+  --download-focus: #fdba74;
+}
+
+.download.blankCells {
+  --download-color: #f8f7ff;
+  --download-bg: linear-gradient(135deg, #a78bfa, #7c3aed);
+  --download-shadow: rgba(124, 58, 237, 0.58);
+  --download-hover-shadow: rgba(124, 58, 237, 0.72);
+  --download-focus: #c4b5fd;
 }
 
 .download:hover {
   transform: translateY(-2px);
   filter: brightness(1.05);
-  box-shadow: 0 20px 42px -12px rgba(33, 163, 102, 0.72);
-}
-
-.download.secondary:hover {
-  box-shadow: 0 20px 42px -12px rgba(37, 99, 235, 0.75);
+  box-shadow: 0 20px 42px -12px var(--download-hover-shadow);
 }
 
 .download:active {
@@ -132,12 +165,8 @@
 }
 
 .download:focus-visible {
-  outline: 2px solid #6ee7b7;
+  outline: 2px solid var(--download-focus);
   outline-offset: 3px;
-}
-
-.download.secondary:focus-visible {
-  outline-color: #7dd3fc;
 }
 
 .download svg {
@@ -225,6 +254,10 @@
     color: #334155;
     background: rgba(2, 6, 12, 0.04);
     border-color: rgba(2, 6, 12, 0.09);
+  }
+
+  .downloads h2 {
+    color: #1e293b;
   }
 
   .preview {

--- a/packages/demo-reactjs/src/App.css
+++ b/packages/demo-reactjs/src/App.css
@@ -154,6 +154,22 @@
   --download-focus: #c4b5fd;
 }
 
+.download.hyperlinks {
+  --download-color: #fff7ed;
+  --download-bg: linear-gradient(135deg, #facc15, #ca8a04);
+  --download-shadow: rgba(202, 138, 4, 0.55);
+  --download-hover-shadow: rgba(202, 138, 4, 0.7);
+  --download-focus: #fde68a;
+}
+
+.download.rtl {
+  --download-color: #f8fafc;
+  --download-bg: linear-gradient(135deg, #14b8a6, #0f766e);
+  --download-shadow: rgba(15, 118, 110, 0.58);
+  --download-hover-shadow: rgba(15, 118, 110, 0.72);
+  --download-focus: #5eead4;
+}
+
 .download:hover {
   transform: translateY(-2px);
   filter: brightness(1.05);

--- a/packages/demo-reactjs/src/App.tsx
+++ b/packages/demo-reactjs/src/App.tsx
@@ -205,6 +205,15 @@ xlsx(data, { fileName: "MySpreadsheet" })`
 
 const features = ["📑 Multi-sheet", "🧱 Multi-table sheets", "🎨 Cell formatting", "⬜ True blank cells", "🟦 TypeScript", "🌐 Browser & Node"]
 
+// Keep each download action visually distinct: new buttons should get a unique
+// color variant and a short label without repeating the "Download" prefix.
+const downloadActions = [
+  { label: "Example", className: "download example", onClick: "downloadFile" },
+  { label: "Styled", className: "download styled", onClick: "downloadStyledFile" },
+  { label: "Multi-table", className: "download multiTable", onClick: "downloadMultiTableFile" },
+  { label: "Blank cells", className: "download blankCells", onClick: "downloadBlankCellFile" },
+] as const
+
 function DownloadIcon() {
   return (
     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
@@ -248,6 +257,13 @@ function App() {
     xlsx(blankCellData, { fileName: "BlankCellSpreadsheet", writeEmptyValuesAsBlankCells: true })
   }
 
+  const downloadHandlers = {
+    downloadFile,
+    downloadStyledFile,
+    downloadMultiTableFile,
+    downloadBlankCellFile,
+  }
+
   return (
     <div className="page">
       <main className="card">
@@ -265,24 +281,17 @@ function App() {
           ))}
         </ul>
 
-        <div className="actions">
-          <button className="download" onClick={downloadFile}>
-            <DownloadIcon />
-            Download example
-          </button>
-          <button className="download secondary" onClick={downloadStyledFile}>
-            <DownloadIcon />
-            Download styled
-          </button>
-          <button className="download secondary" onClick={downloadMultiTableFile}>
-            <DownloadIcon />
-            Download multi-table
-          </button>
-          <button className="download secondary" onClick={downloadBlankCellFile}>
-            <DownloadIcon />
-            Download blank cells
-          </button>
-        </div>
+        <section className="downloads" aria-labelledby="downloads-title">
+          <h2 id="downloads-title">Downloads</h2>
+          <div className="actions">
+            {downloadActions.map((action) => (
+              <button className={action.className} key={action.label} onClick={downloadHandlers[action.onClick]}>
+                <DownloadIcon />
+                {action.label}
+              </button>
+            ))}
+          </div>
+        </section>
 
         <pre className="preview">
           <code>{snippet}</code>

--- a/packages/demo-reactjs/src/App.tsx
+++ b/packages/demo-reactjs/src/App.tsx
@@ -187,6 +187,23 @@ const blankCellData: IJsonSheet[] = [
   },
 ]
 
+// Hyperlink columns turn URL strings into clickable links in Excel.
+const linkData: IJsonSheet[] = [
+  {
+    sheet: "Project links",
+    columns: [
+      { label: "Resource", value: "resource" },
+      { label: "URL", value: "url", format: "hyperlink" },
+      { label: "Owner", value: "owner" },
+    ],
+    content: [
+      { resource: "GitHub repository", url: "https://github.com/LuisEnMarroquin/json-as-xlsx", owner: "Open source" },
+      { resource: "npm package", url: "https://www.npmjs.com/package/json-as-xlsx", owner: "Registry" },
+      { resource: "Live demo", url: "https://xlsx.luismarroquin.com", owner: "Cloudflare Pages" },
+    ],
+  },
+]
+
 const snippet = `import xlsx from "json-as-xlsx"
 
 const data = [{
@@ -212,6 +229,8 @@ const downloadActions = [
   { label: "Styled", className: "download styled", onClick: "downloadStyledFile" },
   { label: "Multi-table", className: "download multiTable", onClick: "downloadMultiTableFile" },
   { label: "Blank cells", className: "download blankCells", onClick: "downloadBlankCellFile" },
+  { label: "Links", className: "download hyperlinks", onClick: "downloadLinkFile" },
+  { label: "RTL", className: "download rtl", onClick: "downloadRtlFile" },
 ] as const
 
 function DownloadIcon() {
@@ -257,11 +276,21 @@ function App() {
     xlsx(blankCellData, { fileName: "BlankCellSpreadsheet", writeEmptyValuesAsBlankCells: true })
   }
 
+  const downloadLinkFile = () => {
+    xlsx(linkData, { fileName: "LinksSpreadsheet" })
+  }
+
+  const downloadRtlFile = () => {
+    xlsx(data, { fileName: "RTLSpreadsheet", RTL: true })
+  }
+
   const downloadHandlers = {
     downloadFile,
     downloadStyledFile,
     downloadMultiTableFile,
     downloadBlankCellFile,
+    downloadLinkFile,
+    downloadRtlFile,
   }
 
   return (

--- a/packages/main-library/package.json
+++ b/packages/main-library/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-as-xlsx",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "license": "MIT",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -12,7 +12,7 @@
   "private": false,
   "scripts": {
     "start": "tsc -p tsconfig.json --watch",
-    "build": "tsc -p tsconfig.json && uglifyjs dist/index.js --output dist/index.js",
+    "build": "tsc -p tsconfig.json && uglifyjs dist/index.js --output dist/index.js && uglifyjs dist/styles.js --output dist/styles.js",
     "test": "jest --coverage"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2026,16 +2026,16 @@ babel-jest@30.4.1:
     graceful-fs "^4.2.11"
     slash "^3.0.0"
 
-babel-plugin-istanbul@7.0.0, babel-plugin-istanbul@^7.0.1:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-7.0.0.tgz#629a178f63b83dc9ecee46fd20266283b1f11280"
-  integrity sha512-C5OzENSx/A+gt7t4VH1I2XsflxyPUmXRFPKBxt33xncdOmq7oROVM3bZv9Ysjjkv8OJYDMa+tKuKMvqU/H3xdw==
+babel-plugin-istanbul@8.0.0, babel-plugin-istanbul@^7.0.1:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-istanbul/-/babel-plugin-istanbul-8.0.0.tgz#8762f542153a52b77e626dd2c033b467de2f2fa2"
+  integrity sha512-18wCskrN3DgbuBmp1gr7LBGT8xdz5xhQQqFvFhVxbkl8VBCrMKQ2YtqBWtUal1Zrc1HTuX0011+Brjw78TCFkg==
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
     "@istanbuljs/load-nyc-config" "^1.0.0"
     "@istanbuljs/schema" "^0.1.3"
     istanbul-lib-instrument "^6.0.2"
-    test-exclude "^6.0.0"
+    test-exclude "^7.0.1"
 
 babel-plugin-jest-hoist@30.4.0:
   version "30.4.0"
@@ -3167,11 +3167,6 @@ fs-minipass@^3.0.0:
   dependencies:
     minipass "^7.0.3"
 
-fs.realpath@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
-  integrity sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==
-
 fsevents@^2.3.3, fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
@@ -3307,7 +3302,7 @@ glob-parent@~5.1.2:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^10.5.0:
+glob@^10.4.1, glob@^10.5.0:
   version "10.5.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-10.5.0.tgz#8ec0355919cd3338c28428a23d4f24ecc5fe738c"
   integrity sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==
@@ -3339,18 +3334,6 @@ glob@^13.0.0:
     minimatch "^10.2.2"
     minipass "^7.1.3"
     path-scurry "^2.0.2"
-
-glob@^7.1.4:
-  version "7.2.3"
-  resolved "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz"
-  integrity sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==
-  dependencies:
-    fs.realpath "^1.0.0"
-    inflight "^1.0.4"
-    inherits "2"
-    minimatch "^3.1.1"
-    once "^1.3.0"
-    path-is-absolute "^1.0.0"
 
 gopd@1.2.0, gopd@^1.2.0:
   version "1.2.0"
@@ -3575,15 +3558,7 @@ indent-string@^4.0.0:
   resolved "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz"
   integrity sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
 
-inflight@^1.0.4:
-  version "1.0.6"
-  resolved "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
-  integrity sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==
-  dependencies:
-    once "^1.3.0"
-    wrappy "1"
-
-inherits@2, inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
+inherits@2.0.4, inherits@^2.0.3, inherits@^2.0.4, inherits@~2.0.3, inherits@~2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
@@ -4692,13 +4667,6 @@ minimatch@3.1.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimatch@^3.0.4, minimatch@^3.1.1:
-  version "3.1.2"
-  resolved "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
-  dependencies:
-    brace-expansion "^1.1.7"
-
 minimatch@^9.0.4:
   version "9.0.9"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.9.tgz#9b0cb9fcb78087f6fd7eababe2511c4d3d60574e"
@@ -5212,7 +5180,7 @@ on-finished@^2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-once@1.4.0, once@^1.3.0, once@^1.4.0:
+once@1.4.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
   integrity sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==
@@ -5461,11 +5429,6 @@ path-exists@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz"
   integrity sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
-
-path-is-absolute@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
-  integrity sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==
 
 path-key@3.1.1, path-key@^3.0.0, path-key@^3.1.0:
   version "3.1.1"
@@ -6347,14 +6310,14 @@ tar@^7.4.3, tar@^7.5.4:
     minizlib "^3.1.0"
     yallist "^5.0.0"
 
-test-exclude@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.npmjs.org/test-exclude/-/test-exclude-6.0.0.tgz"
-  integrity sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+test-exclude@^7.0.1:
+  version "7.0.2"
+  resolved "https://registry.yarnpkg.com/test-exclude/-/test-exclude-7.0.2.tgz#482392077630bc57d5630c13abe908bb910dfc65"
+  integrity sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==
   dependencies:
     "@istanbuljs/schema" "^0.1.2"
-    glob "^7.1.4"
-    minimatch "^3.0.4"
+    glob "^10.4.1"
+    minimatch "^10.2.2"
 
 text-extensions@^1.0.0:
   version "1.9.0"


### PR DESCRIPTION
## Summary

- Prepare the `2.6.3` release by bumping `packages/main-library`, keeping both demo package pins aligned, updating the changelog, and minifying `dist/styles.js` as part of the package build.
- Refresh the React demo downloads by giving each action a distinct visual treatment and adding dedicated **Links** and **RTL** downloads.
- Keep demo parity by adding the Express `/links` endpoint and exposing both links and blank-cells examples from the Express demo page.
- Maintain the toolchain by updating the Istanbul coverage plugin resolution and lockfile, pinning GitHub Actions to explicit versions, and updating the checkout/setup-node workflow actions.
- Strengthen repository guidance in both `AGENTS.md` and `CLAUDE.md` for English-only repo artifacts, `/gacp`, concurrent AI work, and version-bump checklist coverage.

## Why

This PR represents the full `develop` → `main` diff, not just the latest demo commit. It prepares the next package release after the currently deployed/published `2.6.2`, improves demo coverage for visible library features, and cleans up automation/versioning guidance so future release work has fewer loose ends.

## Validation

- `yarn test`
- `yarn build`
- `git diff --check`
- `cmp -s AGENTS.md CLAUDE.md`
- Searched for `2.6.4`, `2.6.3`, and `2.6.2` references to confirm the release pins are aligned and no `2.6.4` references remain.

## Notes

The intended next release version is `2.6.3`; `2.6.4` would skip a release number from the current `2.6.2` deployment.