### PR TITLE
License year 2026, TypeScript tilde pin and main.yml debug fix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,8 +26,9 @@ jobs:
           cp LICENSE packages/main-library/LICENSE
       - name: Set environment variable for GitHub
         run: |
-          echo "CURRENT_VERSION=$(node -e "console.log('v' + require('./package.json').version)")" >> $GITHUB_ENV
-          echo CURRENT_VERSION ${{ env.CURRENT_VERSION }}
+          CURRENT_VERSION="v$(node -p "require('./package.json').version")"
+          echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
+          echo "CURRENT_VERSION $CURRENT_VERSION"
         working-directory: packages/main-library/
       - name: Check if version is already published
         id: check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
           cp LICENSE packages/main-library/LICENSE
       - name: Set environment variable for GitHub
         run: |
-          CURRENT_VERSION="v$(node -p "require('./package.json').version")"
+          CURRENT_VERSION="v$(node -p 'require("./package.json").version')"
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_ENV
           echo "CURRENT_VERSION $CURRENT_VERSION"
         working-directory: packages/main-library/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ same version — always update both together: GitHub Actions reads `.nvmrc`
 (in practice it ignores `.nvmrc`). Keep it on a version supported by the
 toolchain (lerna 9 needs `^20.19 || ^22.12 || >=24`).
 
-TypeScript is intentionally pinned to `^6.0.3` in every package — do not bump it
+TypeScript is intentionally pinned to `~6.0.3` (6.0.x only, matching the tilde
+pin used across the maintainer's other repos) in every package — do not bump it
 to 7.x yet. ts-jest still needs the legacy JS compiler API (e.g.
 `ts.sys.fileExists`) that TypeScript 7 (the Go-native compiler, released
 2026-07-08) removed. Retry the upgrade once ts-jest supports TS 7; everything

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,7 +39,8 @@ same version — always update both together: GitHub Actions reads `.nvmrc`
 (in practice it ignores `.nvmrc`). Keep it on a version supported by the
 toolchain (lerna 9 needs `^20.19 || ^22.12 || >=24`).
 
-TypeScript is intentionally pinned to `^6.0.3` in every package — do not bump it
+TypeScript is intentionally pinned to `~6.0.3` (6.0.x only, matching the tilde
+pin used across the maintainer's other repos) in every package — do not bump it
 to 7.x yet. ts-jest still needs the legacy JS compiler API (e.g.
 `ts.sys.fileExists`) that TypeScript 7 (the Go-native compiler, released
 2026-07-08) removed. Retry the upgrade once ts-jest supports TS 7; everything

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022, LuisEnMarroquin <xlsx@marroquin.dev>
+Copyright (c) 2026, LuisEnMarroquin <xlsx@marroquin.dev>
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/packages/demo-express/package.json
+++ b/packages/demo-express/package.json
@@ -14,6 +14,6 @@
     "json-as-xlsx": "2.6.4",
     "nodemon": "^3.1.14",
     "ts-node": "^10.9.2",
-    "typescript": "^6.0.3"
+    "typescript": "~6.0.3"
   }
 }

--- a/packages/demo-reactjs/package.json
+++ b/packages/demo-reactjs/package.json
@@ -19,7 +19,7 @@
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "vite": "^8.1.4"
   }
 }

--- a/packages/main-library/package.json
+++ b/packages/main-library/package.json
@@ -25,7 +25,7 @@
     "jest": "^30.4.2",
     "jest-cli": "^30.4.2",
     "ts-jest": "^29.4.11",
-    "typescript": "^6.0.3",
+    "typescript": "~6.0.3",
     "uglify-js": "^3.19.3"
   },
   "files": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6523,7 +6523,7 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.9.3.tgz#5b4f59e15310ab17a216f5d6cf53ee476ede670f"
   integrity sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==
 
-typescript@^6.0.3:
+typescript@~6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-6.0.3.tgz#90251dc007916e972786cb94d74d15b185577d21"
   integrity sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==


### PR DESCRIPTION
Follow-up commits that landed on `test` after #118 was merged:

- LICENSE copyright year updated to 2026.
- `typescript` pinned to `~6.0.3` in every package so the range cannot drift past 6.0.x (Copilot follow-up on #118, kept in lockstep with the maintainer's other repos).
- `main.yml`: `CURRENT_VERSION` is computed in a shell variable first so the same-step debug echo prints the real value — values written to `GITHUB_ENV` are only visible to subsequent steps. The quoting itself was always valid (that step published 2.6.4 successfully).

Merging does **not** publish: 2.6.4 is already on npm, so the publish guard skips it and only the GitHub Pages deploy runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)